### PR TITLE
test: add a custodian template and unit test

### DIFF
--- a/assets/mappings/mon-mothma-covid.json
+++ b/assets/mappings/mon-mothma-covid.json
@@ -46,11 +46,7 @@
         },
         "phone": {
           "use": "WP",
-          "value": "555-777-0123"
-        },
-        "fax": {
-          "use": "WP",
-          "value": "555-777-0124"
+          "value": "+1-888-000-9999"
         }
       }
     },
@@ -164,7 +160,7 @@
         }
       }
     },
-    "author":{
+    "author": {
       "time": "20250215150045-0400",
       "contact": {
         "address": {
@@ -176,14 +172,14 @@
           "county": "Administrative Core",
           "country": "Coruscant"
         },
-      "phone": {
-        "use": "WP",
-        "value": "+1-888-000-9999"
-      },
-      "fax": {
-        "use": "WP",
-        "value": "+1-888-000-1111"
-      }
+        "phone": {
+          "use": "WP",
+          "value": "+1-888-000-9999"
+        },
+        "fax": {
+          "use": "WP",
+          "value": "+1-888-000-1111"
+        }
       },
       "manufacturerModelName": "EpicCore Galactic - Version 45.7",
       "softwareName": "EpicCore Galactic - Version 45.7"

--- a/assets/templates/components/custodian.xml.j2
+++ b/assets/templates/components/custodian.xml.j2
@@ -1,0 +1,26 @@
+{#- custodian template for custodian in an eICR document -#}
+{%- macro format_address(addr) %}
+    <addr use="{{ addr.use }}">
+    {%- if addr.street %}<streetAddressLine>{{ addr.street }}</streetAddressLine>{%- endif %}
+        {%- if addr.city %}<city>{{ addr.city }}</city>{%- endif %}
+            {%- if addr.state %}<state>{{ addr.state }}</state>{%- endif %}
+                {%- if addr.zip %}<postalCode>{{ addr.zip }}</postalCode>{%- endif %}
+                    {%- if addr.county %}<county>{{ addr.county }}</county>{%- endif %}
+                        {%- if addr.country %}<country>{{ addr.country }}</country>{%- endif %}
+                            </addr>
+                        {%- endmacro %}
+                        {%- macro format_telecom(phone=None, fax=None) %}
+                            {%- if phone %}<telecom use="{{ phone.use }}" value="tel:{{ phone.value }}" />{%- endif %}
+                                {%- if fax %}<telecom use="{{ fax.use }}" value="fax:{{ fax.value }}" />{%- endif %}
+                                {%- endmacro %}
+                                <custodian xmlns="{{ nsmap[None] }}" xmlns:xsi="{{ nsmap['xsi'] }}">
+                                <assignedCustodian>
+                                <representedCustodianOrganization>
+                                {#- Custodian ID (NPI) -#}
+                                <id extension="{{ facility.id }}" root="2.16.840.1.113883.4.6" />
+                                <name>{{ facility.name }}</name>
+                                {%- if facility.contact %}{{ format_telecom(facility.contact.phone, facility.contact.fax) }}{%- endif %}
+                                    {%- if facility.contact.address %}{{ format_address(facility.contact.address) }}{%- endif %}
+                                        </representedCustodianOrganization>
+                                        </assignedCustodian>
+                                        </custodian>

--- a/tests/test-component-templates.py
+++ b/tests/test-component-templates.py
@@ -58,3 +58,33 @@ def test_author_template(jinja_env, patient_data, xml_nsmap, base_path):
         print("\nNormalized Expected XML:")
         print(normalized_expected)
         raise
+
+
+def test_custodian_template(jinja_env, patient_data, xml_nsmap, base_path):
+    """Test that our template generates the expected custodian XML structure."""
+    # load and render the template
+    template = jinja_env.get_template("components/custodian.xml.j2")
+    rendered_xml = template.render(
+        facility=patient_data["components"]["facility"], nsmap=xml_nsmap
+    )
+
+    # load and extract the expected xml
+    xml_path = base_path / "tests" / "assets" / "mon-mothma-covid-problem_eicr.xml"
+    tree = etree.parse(str(xml_path))
+    custodian = tree.find(".//{urn:hl7-org:v3}custodian")
+    expected_xml = etree.tostring(custodian, encoding="unicode")
+
+    # compare normalized versions
+    normalized_rendered = normalize_xml(rendered_xml)
+    normalized_expected = normalize_xml(expected_xml)
+
+    # for debugging, print both versions if they don't match
+    try:
+        assert normalized_rendered == normalized_expected
+    except AssertionError:
+        print("\nNormalized Generated XML:")
+        print(normalized_rendered)
+        print("\nNormalized Expected XML:")
+        print(normalized_expected)
+        raise
+


### PR DESCRIPTION
# PULL REQUEST

## Summary

We're adding a template for `<custodian>` and a unit test for `<custodian>`.

## Related Issue

Fixes #11 
- #11 

## Acceptance Criteria


 -  Given a JSON object that represents `<custodian>` data
 -  When it is the input to a `jinja2` template
 -  Then the XML `<custodian>` block matches the expected structure
