### PR TITLE
Add participant test and template

### DIFF
--- a/assets/mappings/mon-mothma-covid.json
+++ b/assets/mappings/mon-mothma-covid.json
@@ -187,6 +187,30 @@
       },
       "manufacturerModelName": "EpicCore Galactic - Version 45.7",
       "softwareName": "EpicCore Galactic - Version 45.7"
+    },
+    "participant":{
+      "contact": {
+        "address": {
+          "use": "WP",
+          "street": "500 Republica, Suite 400",
+          "city": "Senate District",
+          "state": "Galactic City",
+          "zip": "GC-500",
+          "county": "Administrative Core",
+          "country": "Coruscant"
+        },
+        "phone": {
+          "use": "MC",
+          "value": "+1-555-555-9877"
+        }
+      },
+      "associatedPerson": {
+        "name": {
+          "prefix": "Mr",
+          "given": "Perrin",
+          "family": "Fertha"
+        }
+      }
     }
   },
   "patterns": {

--- a/assets/templates/components/participant.xml.j2
+++ b/assets/templates/components/participant.xml.j2
@@ -1,0 +1,21 @@
+{% if participant %}<participant typeCode="IND">
+    <time nullFlavor="UNK" />
+    <associatedEntity classCode="ECON">
+        <addr use="H">
+            {% if participant.contact.address.street %}<streetAddressLine>{{ participant.contact.address.street }}</streetAddressLine>{% endif %}
+            {% if participant.contact.address.city %}<city>{{ participant.contact.address.city }}</city>{% endif %}
+            {% if participant.contact.address.state %}<state>{{ participant.contact.address.state }}</state>{% endif %}
+            {% if participant.contact.address.zip %}<postalCode>{{ participant.contact.address.zip }}</postalCode>{% endif %}
+            {% if participant.contact.address.county %}<county>{{ participant.contact.address.county }}</county>{% endif %}
+            {% if participant.contact.address.country %}<country>{{ participant.contact.address.country }}</country>{% endif %}
+        </addr>
+        {% if participant.contact.phone.value %}<telecom value="tel:{{ participant.contact.phone.value }}" use="{{ participant.contact.phone.use }}" />{% endif %}
+        {% if participant.associatedPerson %}<associatedPerson>
+            <name use="L">
+            {% if participant.associatedPerson.name.prefix %}<prefix>{{ participant.associatedPerson.name.prefix }}</prefix>{% endif %}
+            {% if participant.associatedPerson.name.given %}<given>{{ participant.associatedPerson.name.given }}</given>{% endif %}
+                {% if participant.associatedPerson.name.family %} <family>{{ participant.associatedPerson.name.family }}</family>{% endif %}
+            </name>
+        </associatedPerson>{% endif %}
+    </associatedEntity>
+</participant>{% endif %}

--- a/tests/assets/mon-mothma-covid-problem_eicr.xml
+++ b/tests/assets/mon-mothma-covid-problem_eicr.xml
@@ -114,7 +114,7 @@
         <streetAddressLine>500 Republica, Suite 400</streetAddressLine>
         <city>Senate District</city>
         <state>Galactic City</state>
-        <potalCode>GC-500</potalCode>
+        <postalCode>GC-500</postalCode>
         <county>Administrative Core</county>
         <country>Coruscant</country>
       </addr>
@@ -225,7 +225,7 @@
       <component>
         <section>
           <!-- [C-CDA R1.1] Encounters Section (entries optional) -->
-          <templateId root="2.16.840.1.113883.10.20.22.2.22" />
+          <templateId root="2.16.840.1.113883.10.20.22.2.22" />Y
           <!-- [C-CDA R2.1] Encounters Section (entries optional) (V3) -->
           <templateId extension="2015-08-01"
             root="2.16.840.1.113883.10.20.22.2.22" />

--- a/tests/test-component-templates.py
+++ b/tests/test-component-templates.py
@@ -58,3 +58,32 @@ def test_author_template(jinja_env, patient_data, xml_nsmap, base_path):
         print("\nNormalized Expected XML:")
         print(normalized_expected)
         raise
+
+def test_participant_template(jinja_env, patient_data, xml_nsmap, base_path):
+    """Test that our template generates the expected participant XML structure.
+    Participant is used in the eCR XML for emergency contact data."""
+    # load and render the template
+    template = jinja_env.get_template("components/participant.xml.j2")
+    rendered_xml = template.render(
+        participant=patient_data["components"]["participant"], nsmap=xml_nsmap
+    )
+
+    # load and extract the expected xml
+    xml_path = base_path / "tests" / "assets" / "mon-mothma-covid-problem_eicr.xml"
+    tree = etree.parse(str(xml_path))
+    participant = tree.find(".//{urn:hl7-org:v3}participant")
+    expected_xml = etree.tostring(participant, encoding="unicode")
+
+    # compare normalized versions
+    normalized_rendered = normalize_xml(rendered_xml)
+    normalized_expected = normalize_xml(expected_xml)
+
+    # for debugging, print both versions if they don't match
+    try:
+        assert normalized_rendered == normalized_expected
+    except AssertionError:
+        print("\nNormalized Generated XML:")
+        print(normalized_rendered)
+        print("\nNormalized Expected XML:")
+        print(normalized_expected)
+        raise


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds another template and test for the participant/emergency contact chunk of the XML

## Related Issue

Fixes #
- #13 

## Acceptance Criteria

 -  Given a JSON object that represents emergency contact data
 -  When it is the input to a `jinja2` template
 -  Then the XML `<participant>` block matches the expected structure
