### PR TITLE
add medications administered and history of present illness template

### DIFF
--- a/assets/mappings/mon-mothma-covid.json
+++ b/assets/mappings/mon-mothma-covid.json
@@ -183,6 +183,12 @@
       },
       "manufacturerModelName": "EpicCore Galactic - Version 45.7",
       "softwareName": "EpicCore Galactic - Version 45.7"
+    },
+    "historyOfPresentIllness": {
+      "text": "<paragraph>Since February 16, 2025 the patient has had difficulty\n              breathing and a fever; </paragraph>"
+    },
+    "medicationsAdministered": {
+      "text": "No medications administered"
     }
   },
   "patterns": {

--- a/assets/templates/components/history-of-present-illness.xml.j2
+++ b/assets/templates/components/history-of-present-illness.xml.j2
@@ -1,0 +1,13 @@
+{% if historyOfPresentIllness.text %}
+    <!-- History of Present Illness Section -->
+    <component>
+    <section>
+        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
+        <code code="10164-2" codeSystem="2.16.840.1.113883.6.1"
+              codeSystemName="LOINC" displayName="History of Present Illness" />
+        <title>History of Present Illness</title>
+        {% if historyOfPresentIllness.text %}
+            <text mediaType="text/x-hl7-text+xml">{{ historyOfPresentIllness.text }}</text>
+        {% endif %}
+    </section>
+</component>{% endif %}

--- a/assets/templates/components/medications-administered.xml.j2
+++ b/assets/templates/components/medications-administered.xml.j2
@@ -1,0 +1,13 @@
+{% if medicationsAdministered.text %}<component>
+    <section nullFlavor="NI">
+        <!-- [C-CDA R1.1] Medications Administered Section -->
+        <templateId root="2.16.840.1.113883.10.20.22.2.38" />
+        <!-- [C-CDA R2.0] Medications Administered Section (V2) -->
+        <templateId extension="2014-06-09"
+                    root="2.16.840.1.113883.10.20.22.2.38" />
+        <code code="29549-3" codeSystem="2.16.840.1.113883.6.1"
+              codeSystemName="LOINC" displayName="Medications Administered" />
+        <title>Medications Administered</title>
+        {% if medicationsAdministered.text %}<text>{{ medicationsAdministered.text }}</text>{% endif %}
+    </section>
+</component>{% endif %}

--- a/tests/assets/mon-mothma-covid-problem_eicr.xml
+++ b/tests/assets/mon-mothma-covid-problem_eicr.xml
@@ -129,7 +129,7 @@
     </associatedEntity>
   </participant>
 
-  <!-- componentOf: contains the encompassingEncouter and the provider and facility infomation for
+  <!-- componentOf: contains the encompassingEncounter and the provider and facility information for
   the case -->
   <componentOf>
     <!-- encounter ID-->
@@ -217,9 +217,9 @@
     </encompassingEncounter>
   </componentOf>
 
-  <!-- first component holds the structredBody -->
+  <!-- first component holds the structuredBody -->
   <component>
-    <!-- structredBody contains all of the clinical sections of the eICR -->
+    <!-- structuredBody contains all clinical sections of the eICR -->
     <structuredBody>
       <!-- Encounters section -->
       <component>

--- a/tests/test-component-templates.py
+++ b/tests/test-component-templates.py
@@ -88,3 +88,60 @@ def test_custodian_template(jinja_env, patient_data, xml_nsmap, base_path):
         print(normalized_expected)
         raise
 
+
+def test_medications_administered_template(jinja_env, patient_data, xml_nsmap, base_path):
+    """Test that our template generates the expected medications administered XML structure."""
+    # load and render the template
+    template = jinja_env.get_template("components/medications-administered.xml.j2")
+    rendered_xml = template.render(
+        medicationsAdministered=patient_data["components"]["medicationsAdministered"], nsmap=xml_nsmap
+    )
+
+    # load and extract the expected xml
+    xml_path = base_path / "tests" / "assets" / "mon-mothma-covid-problem_eicr.xml"
+    tree = etree.parse(str(xml_path))
+    all_components = tree.findall(".//{urn:hl7-org:v3}component")
+    expected_xml = etree.tostring(all_components[3], encoding="unicode")
+
+    # compare normalized versions
+    normalized_rendered = normalize_xml(rendered_xml)
+    normalized_expected = normalize_xml(expected_xml)
+
+    # for debugging, print both versions if they don't match
+    try:
+        assert normalized_rendered == normalized_expected
+    except AssertionError:
+        print("\nNormalized Generated XML:")
+        print(normalized_rendered)
+        print("\nNormalized Expected XML:")
+        print(normalized_expected)
+        raise
+
+
+def test_history_of_present_illness_template(jinja_env, patient_data, xml_nsmap, base_path):
+    """Test that our template generates the expected History of Present Illness XML structure."""
+    # load and render the template
+    template = jinja_env.get_template("components/history-of-present-illness.xml.j2")
+    rendered_xml = template.render(
+        historyOfPresentIllness=patient_data["components"]["historyOfPresentIllness"], nsmap=xml_nsmap
+    )
+
+    # load and extract the expected xml
+    xml_path = base_path / "tests" / "assets" / "mon-mothma-covid-problem_eicr.xml"
+    tree = etree.parse(str(xml_path))
+    all_components = tree.findall(".//{urn:hl7-org:v3}component")
+    expected_xml = etree.tostring(all_components[2], encoding="unicode")
+
+    # compare normalized versions
+    normalized_rendered = normalize_xml(rendered_xml)
+    normalized_expected = normalize_xml(expected_xml)
+
+    # for debugging, print both versions if they don't match
+    try:
+        assert normalized_rendered == normalized_expected
+    except AssertionError:
+        print("\nNormalized Generated XML:")
+        print(normalized_rendered)
+        print("\nNormalized Expected XML:")
+        print(normalized_expected)
+        raise


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds tests and templates for medications administered and history of present illness

## Related Issue

Fixes #
- #15 

## Acceptance Criteria
 -  Given JSON objects that represent history of present illness data and medication administered
 -  When it is the input to a `jinja2` template
 -  Then the XML `<section>` blocks matches the expected structures
