### PR TITLE
Create encompassing encounter template + test

### DIFF
--- a/assets/mappings/mon-mothma-covid.json
+++ b/assets/mappings/mon-mothma-covid.json
@@ -47,6 +47,10 @@
         "phone": {
           "use": "WP",
           "value": "+1-888-000-9999"
+        },
+        "fax": {
+          "use": "WP",
+          "value": "+1-888-000-1111"
         }
       }
     },
@@ -75,6 +79,10 @@
         "email": {
           "use": "WP",
           "value": "dr.hemlock@grmfc.gc.example.com"
+        },
+        "fax": {
+          "use": "WP",
+          "value": "+1-555-777-0987"
         }
       }
     },

--- a/assets/templates/components/encompassing-encounter.xml.j2
+++ b/assets/templates/components/encompassing-encounter.xml.j2
@@ -1,0 +1,95 @@
+{% set facility = data.components.facility %}
+{% set provider = data.components.provider %}
+{% set patterns = data.patterns %}
+<componentOf>
+    <encompassingEncounter>
+        <id extension="9937012" root="2.16.840.1.113883.19" />
+        <code code="AMB" codeSystem="2.16.840.1.113883.5.4"
+              codeSystemName="HL7 ActEncounterCode" displayName="Ambulatory" />
+        {%- if patterns.lab_confirmed.versions.initial.timing.encounterDate %}<effectiveTime>
+            <low value="{{ patterns.lab_confirmed.versions.initial.timing.encounterDate|replace('-', '') }}" />
+            <high value="{{ patterns.lab_confirmed.versions.initial.timing.encounterDate|replace('-', '') }}" />
+        </effectiveTime>{%- endif %}
+        <responsibleParty>
+            <assignedEntity>
+                <!-- Provider ID (NPI) -->
+                <id extension="{{ provider.id }}" root="2.16.840.1.113883.4.6" />
+                {%- if provider.contact.address.street %}
+                <addr use="H">
+                    {%- if provider.contact.address.street %} <streetAddressLine>{{ provider.contact.address.street }}</streetAddressLine>{%- endif %}
+                    {%- if provider.contact.address.city %} <city>{{ provider.contact.address.city }}</city>{%- endif %}
+                    {%- if provider.contact.address.state %} <state>{{ provider.contact.address.state }}</state>{%- endif %}
+                    {%- if provider.contact.address.zip %} <postalCode>{{ provider.contact.address.zip }}</postalCode>{%- endif %}
+                    {%- if provider.contact.address.county %} <county>{{ provider.contact.address.county }}</county>{%- endif %}
+                    {%- if provider.contact.address.country %} <country>{{ provider.contact.address.country }}</country>{%- endif %}
+                </addr>
+                {%- endif %}
+                {%- if provider.contact.phone.value %}<telecom use="WP" value="tel:{{ provider.contact.phone.value }}" />{%- endif %}
+                {%- if provider.contact.fax.value %}<telecom use="WP" value="fax:{{ provider.contact.fax.value }}" />{%- endif %}
+                {%- if provider.contact.email.value %}<telecom use="WP" value="mailto:{{ provider.contact.email.value }}" />{%- endif %}
+                <assignedPerson>
+                    {%- if provider.name %}<name>
+                        {%- if provider.name.prefix %}<prefix>{{ provider.name.prefix }}</prefix>{%- endif %}
+                        {%- if provider.name.given %}<given>{{ provider.name.given }}</given>{%- endif %}
+                        {%- if provider.name.family %}<family>{{ provider.name.family }}</family>{%- endif %}
+                        {%- if provider.name.suffix %}<suffix>{{ provider.name.suffix }}</suffix>{%- endif %}
+                    </name>{%- endif %}
+                </assignedPerson>
+                <representedOrganization>
+                    <!-- Represented Organization-->
+                    <id extension="{{ facility.id }}" root="2.16.840.1.113883.4.6" />
+                    <!-- Provider Facility/Office Name-->
+                    {%- if facility.name %}<name>{{ facility.name }}</name>{%- endif %}
+                    {%- if facility.contact.address %}
+                    <addr use="{{ facility.contact.address.use }}">
+                        {%- if facility.contact.address.street %}<streetAddressLine>{{ facility.contact.address.street }}</streetAddressLine>{%- endif %}
+                        {%- if facility.contact.address.city %}<city>{{ facility.contact.address.city }}</city>{%- endif %}
+                        {%- if facility.contact.address.state %}<state>{{ facility.contact.address.state }}</state>{%- endif %}
+                        {%- if facility.contact.address.state %}<postalCode>{{ facility.contact.address.zip }}</postalCode>{%- endif %}
+                        {%- if facility.contact.address.state %}<county>{{ facility.contact.address.county }}</county>{%- endif %}
+                        {%- if facility.contact.address.state %}<country>{{ facility.contact.address.country }}</country>{%- endif %}
+                    </addr>
+                    {%- endif %}
+                </representedOrganization>
+            </assignedEntity>
+        </responsibleParty>
+        {%- if facility %}
+        <location>
+            <healthCareFacility>
+                <!-- Facility ID (NPI) -->
+                <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+                <code code="{{ facility.type.code }}" codeSystem="2.16.840.1.113883.5.111"
+                      codeSystemName="HL7RoleCode" displayName="{{ facility.type.displayName }}" />
+                <location>
+                    {%- if facility.contact.address %}
+                    <addr use="{{ facility.contact.address.use }}">
+                        {%- if facility.contact.address.street %}<streetAddressLine>{{ facility.contact.address.street }}</streetAddressLine>{%- endif %}
+                        {%- if facility.contact.address.city %}<city>{{ facility.contact.address.city }}</city>{%- endif %}
+                        {%- if facility.contact.address.state %}<state>{{ facility.contact.address.state }}</state>{%- endif %}
+                        {%- if facility.contact.address.state %}<postalCode>{{ facility.contact.address.zip }}</postalCode>{%- endif %}
+                        {%- if facility.contact.address.state %}<county>{{ facility.contact.address.county }}</county>{%- endif %}
+                        {%- if facility.contact.address.state %}<country>{{ facility.contact.address.country }}</country>{%- endif %}
+                    </addr>
+                    {%- endif %}
+                </location>
+                <serviceProviderOrganization>
+                    <!-- Provider Facility/Office Name-->
+                    {%- if facility.name %}<name>{{ facility.name }}</name>{%- endif %}
+                    {%- if facility.contact.phone.value %}<telecom use="WP" value="tel:{{ facility.contact.phone.value }}" />{%- endif %}
+                    {%- if facility.contact.fax.value %}<telecom use="WP" value="fax:{{ facility.contact.fax.value }}" />{%- endif %}
+                    {%- if facility.contact.address %}
+                    <addr use="{{ facility.contact.address.use }}">
+                        {%- if facility.contact.address.street %}<streetAddressLine>{{ facility.contact.address.street }}</streetAddressLine>{%- endif %}
+                        {%- if facility.contact.address.state %}<city>{{ facility.contact.address.city }}</city>{%- endif %}
+                        {%- if facility.contact.address.state %}<state>{{ facility.contact.address.state }}</state>{%- endif %}
+                        {%- if facility.contact.address.state %}<postalCode>{{ facility.contact.address.zip }}</postalCode>{%- endif %}
+                        {%- if facility.contact.address.state %}<county>{{ facility.contact.address.county }}</county>{%- endif %}
+                        {%- if facility.contact.address.state %}<country>{{ facility.contact.address.country }}</country>{%- endif %}
+                    </addr>
+                    {%- endif %}
+                </serviceProviderOrganization>
+            </healthCareFacility>
+        </location>
+        {%- endif %}
+    </encompassingEncounter>
+</componentOf>

--- a/tests/assets/mon-mothma-covid-problem_eicr.xml
+++ b/tests/assets/mon-mothma-covid-problem_eicr.xml
@@ -94,6 +94,7 @@
         <id extension="1234567893" root="2.16.840.1.113883.4.6" />
         <name>Grand Republic Medical Facility Clinic</name>
         <telecom use="WP" value="tel:+1-888-000-9999" />
+        <telecom use="WP" value="fax:+1-888-000-1111" />
         <addr use="WP">
           <streetAddressLine>500 Republica Medical Plaza, Suite 1000</streetAddressLine>
           <city>Senate District</city>
@@ -138,8 +139,8 @@
       <code code="AMB" codeSystem="2.16.840.1.113883.5.4"
         codeSystemName="HL7 ActEncounterCode" displayName="Ambulatory" />
       <effectiveTime>
-        <low value="20250216" />
-        <high value="20250216" />
+        <low value="20250220" />
+        <high value="20250220" />
       </effectiveTime>
       <responsibleParty>
         <assignedEntity>
@@ -153,7 +154,7 @@
             <county>Administrative Core</county>
             <country>Coruscant</country>
           </addr>
-          <telecom use="WP" value="tel:+1-555-777-0123" />
+          <telecom use="WP" value="tel:555-555-4321" />
           <telecom use="WP" value="fax:+1-555-777-0987" />
           <telecom use="WP" value="mailto:dr.hemlock@grmfc.gc.example.com" />
           <assignedPerson>

--- a/tests/test-component-templates.py
+++ b/tests/test-component-templates.py
@@ -88,3 +88,32 @@ def test_custodian_template(jinja_env, patient_data, xml_nsmap, base_path):
         print(normalized_expected)
         raise
 
+
+def test_encompassing_encounter_template(jinja_env, patient_data, xml_nsmap, base_path):
+    """Test that our template generates the expected encompassing encounter XML structure."""
+    # load and render the template
+    template = jinja_env.get_template("components/encompassing-encounter.xml.j2")
+
+    rendered_xml = template.render(
+        data=patient_data, nsmap=xml_nsmap
+    )
+
+    # load and extract the expected xml
+    xml_path = base_path / "tests" / "assets" / "mon-mothma-covid-problem_eicr.xml"
+    tree = etree.parse(str(xml_path))
+    encompassing_encounter = tree.find(".//{urn:hl7-org:v3}componentOf")
+    expected_xml = etree.tostring(encompassing_encounter, encoding="unicode")
+
+    # compare normalized versions
+    normalized_rendered = normalize_xml(rendered_xml)
+    normalized_expected = normalize_xml(expected_xml)
+
+    # for debugging, print both versions if they don't match
+    try:
+        assert normalized_rendered == normalized_expected
+    except AssertionError:
+        print("\nNormalized Generated XML:")
+        print(normalized_rendered)
+        print("\nNormalized Expected XML:")
+        print(normalized_expected)
+        raise


### PR DESCRIPTION
# PULL REQUEST

## Summary

Adds a jinja2 template for encompassing encounter plus a test

## Related Issue

Fixes #
- #16 

## Acceptance Criteria

 -  Given JSON objects that represent Encompassing Encounter data
 -  When it is the input to a `jinja2` template
 -  Then the XML `<EncompassingEncounter>` blocks matches the expected structures
