### PR TITLE
feat: Adding ECR generator script with templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ be much easier to update than editing an ECR xml directly so please keep this in
   - Sections that still need to be templated
   - Initial Case Report Trigger Code template ids
   - Travel History needs to be an array of data
+  - Fix old unit tests
 
 ## Standard Notices
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,77 @@
-# CDCgov GitHub Organization Open Source Project Template
+# Star Wars - ECR Data Generator 
 
-**Template for clearance: This project serves as a template to aid projects in starting up and moving through clearance procedures. To start, create a new repository and implement the required [open practices](open_practices.md), train on and agree to adhere to the organization's [rules of behavior](rules_of_behavior.md), and [send a request through the create repo form](https://forms.office.com/Pages/ResponsePage.aspx?id=aQjnnNtg_USr6NJ2cHf8j44WSiOI6uNOvdWse4I-C2NUNk43NzMwODJTRzA4NFpCUk1RRU83RTFNVi4u) using language from this template as a Guide.**
-
-**General disclaimer** This repository was created for use by CDC programs to collaborate on public health related projects in support of the [CDC mission](https://www.cdc.gov/about/cdc/#cdc_about_cio_mission-our-mission).  GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners to share information and collaborate on software. CDC use of GitHub does not imply an endorsement of any one particular service, product, or enterprise. 
-
-## Access Request, Repo Creation Request
-
-* [CDC GitHub Open Project Request Form](https://forms.office.com/Pages/ResponsePage.aspx?id=aQjnnNtg_USr6NJ2cHf8j44WSiOI6uNOvdWse4I-C2NUNk43NzMwODJTRzA4NFpCUk1RRU83RTFNVi4u) _[Requires a CDC Office365 login, if you do not have a CDC Office365 please ask a friend who does to submit the request on your behalf. If you're looking for access to the CDCEnt private organization, please use the [GitHub Enterprise Cloud Access Request form](https://forms.office.com/Pages/ResponsePage.aspx?id=aQjnnNtg_USr6NJ2cHf8j44WSiOI6uNOvdWse4I-C2NUQjVJVDlKS1c0SlhQSUxLNVBaOEZCNUczVS4u).]_
-
-## Related documents
-
-* [Open Practices](open_practices.md)
-* [Rules of Behavior](rules_of_behavior.md)
-* [Thanks and Acknowledgements](thanks.md)
-* [Disclaimer](DISCLAIMER.md)
-* [Contribution Notice](CONTRIBUTING.md)
-* [Code of Conduct](code-of-conduct.md)
+General disclaimer - This repository was created for use by CDC programs to collaborate 
+on public health related projects in support of the CDC mission. 
+GitHub is not hosted by the CDC, but is a third party website used by CDC and its partners 
+to share information and collaborate on software. CDC use of GitHub does not imply an endorsement 
+of any one particular service, product, or enterprise.
 
 ## Overview
 
-Describe the purpose of your project. Add additional sections as necessary to help collaborators and potential collaborators understand and use your project.
-  
-## Public Domain Standard Notice
+This repository contains templates and script to aid in generating synthetic ECR data for the purposes
+of testing other systems. 
+
+### Components
+ECRs are generated using Jinja2 templates which are located under `assets/templates`.
+Files under `assets/mappings` are JSON data files that will feed into these template files via the
+`scripts/generate_ecr.py` script which reads the JSON data file, sets up the Jinja2 environment, sets 
+some additional globals, and renders the base template (`assets/templates/components/base.xml.j2`).
+
+### Setup
+- Clone this repo
+- Install Python > 3.12
+- Install pip-tools (replace the `x` with the actual version of Python you have)
+    
+    ```
+    > pip3.x install pip-tools
+    ```
+    
+- Compile TOML file (generates a requirement.txt file)
+    
+    ```
+    > python3.x -m piptools compile pyproject.toml
+    ```
+    
+- Install dependencies
+    
+    ```
+    > pip3.x install -r requirements.txt
+    ```
+
+### How to generate a test ECR
+Use an existing JSON mapping data file in `assets/mappins` or create your own. 
+Most sections are required except the `config` section which includes configs on repeatable
+resources for generating very large ECRs (usually needed for performance and load testing).
+
+To generate an ECR using the default `mon-mothma-covid.json` data file simply go to the `scripts` dir and run:
+```
+> generate_ecr.py
+```
+
+To use another data file use the `-m` arg (which will look for the file in the `assets/mappings` folder):
+```
+> generate_ecr.py -m <filename>.json
+```
+The file will be written to the `scripts` folder named `<data_filename>-<timestamp>.xml`.
+ 
+## Future Improvements
+This is just an initial version but the main goal was to make the data mapping JSON files 
+be much easier to update than editing an ECR xml directly so please keep this in mind when making changes.
+
+### Future improvements can include (but are not limited to):
+- Randomly generating data (instead of just repeating it)
+  - This could include adding lookup files for codeSystems so that we can randomly choose from them (needs some thought)
+- Trigger codes needs to be supported properly (this includes sdtc fields)
+- Create a macro for codes
+- Timestamps and status codes are not templated - should they be? 
+- Address `TODO`s which include
+  - Sections that still need to be templated
+  - Initial Case Report Trigger Code template ids
+  - Travel History needs to be an array of data
+
+## Standard Notices
+
+### Public Domain Standard Notice
 This repository constitutes a work of the United States Government and is not
 subject to domestic copyright protection under 17 USC § 105. This repository is in
 the public domain within the United States, and copyright and related rights in
@@ -30,7 +80,7 @@ All contributions to this repository will be released under the CC0 dedication. 
 submitting a pull request you are agreeing to comply with this waiver of
 copyright interest.
 
-## License Standard Notice
+### License Standard Notice
 The repository utilizes code licensed under the terms of the Apache Software
 License and therefore is licensed under ASL v2 or later.
 
@@ -47,14 +97,14 @@ program. If not, see http://www.apache.org/licenses/LICENSE-2.0.html
 
 The source code forked from other open source projects will inherit its license.
 
-## Privacy Standard Notice
+### Privacy Standard Notice
 This repository contains only non-sensitive, publicly available data and
 information. All material and community participation is covered by the
 [Disclaimer](DISCLAIMER.md)
 and [Code of Conduct](code-of-conduct.md).
 For more information about CDC's privacy policy, please visit [http://www.cdc.gov/other/privacy.html](https://www.cdc.gov/other/privacy.html).
 
-## Contributing Standard Notice
+### Contributing Standard Notice
 Anyone is encouraged to contribute to the repository by [forking](https://help.github.com/articles/fork-a-repo)
 and submitting a pull request. (If you are new to GitHub, you might start with a
 [basic tutorial](https://help.github.com/articles/set-up-git).) By contributing
@@ -66,10 +116,19 @@ later.
 All comments, messages, pull requests, and other submissions received through
 CDC including this GitHub page may be subject to applicable federal law, including but not limited to the Federal Records Act, and may be archived. Learn more at [http://www.cdc.gov/other/privacy.html](http://www.cdc.gov/other/privacy.html).
 
-## Records Management Standard Notice
+### Records Management Standard Notice
 This repository is not a source of government records, but is a copy to increase
 collaboration and collaborative potential. All government records will be
 published through the [CDC web site](http://www.cdc.gov).
 
-## Additional Standard Notices
+### Additional Standard Notices
 Please refer to [CDC's Template Repository](https://github.com/CDCgov/template) for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/main/CONTRIBUTING.md), [public domain notices and disclaimers](https://github.com/CDCgov/template/blob/main/DISCLAIMER.md), and [code of conduct](https://github.com/CDCgov/template/blob/main/code-of-conduct.md).
+
+## Related documents
+
+* [Open Practices](open_practices.md)
+* [Rules of Behavior](rules_of_behavior.md)
+* [Thanks and Acknowledgements](thanks.md)
+* [Disclaimer](DISCLAIMER.md)
+* [Contribution Notice](CONTRIBUTING.md)
+* [Code of Conduct](code-of-conduct.md)

--- a/assets/mappings/mon-mothma-covid.json
+++ b/assets/mappings/mon-mothma-covid.json
@@ -26,6 +26,40 @@
       "softwareName": "EpicCore Galactic - Version 45.7"
     }
   },
+  "addresses":{
+    "person": {
+      "use": "WP",
+      "street": "200 Corusca Street",
+      "city": "Senate District",
+      "state": "Galactic City",
+      "zip": "GC-500",
+      "county": "Administrative Core",
+      "country": "Coruscant"
+    },
+    "organization": {
+      "use": "WP",
+      "street": "500 Republica Medical Plaza, Suite 1000",
+      "city": "Senate District",
+      "state": "Galactic City",
+      "zip": "GC-500",
+      "county": "Administrative Core",
+      "country": "Coruscant"
+    }
+  },
+  "telecom": {
+    "phone": {
+      "use": "WP",
+      "value": "+1-888-000-9999"
+    },
+    "fax": {
+      "use": "WP",
+      "value": "+1-555-777-0582"
+    },
+    "email": {
+      "use": "WP",
+      "value": "an.email@grmfc.gc.example.com"
+    }
+  },
   "components": {
     "facility": {
       "id": "1234567893",
@@ -33,21 +67,6 @@
       "type": {
         "code": "OF",
         "displayName": "Outpatient Facility"
-      },
-      "contact": {
-        "address": {
-          "use": "WP",
-          "street": "500 Republica Medical Plaza, Suite 1000",
-          "city": "Senate District",
-          "state": "Galactic City",
-          "zip": "GC-500",
-          "county": "Administrative Core",
-          "country": "Coruscant"
-        },
-        "phone": {
-          "use": "WP",
-          "value": "+1-888-000-9999"
-        }
       }
     },
     "provider": {
@@ -57,25 +76,6 @@
         "given": "Royce",
         "family": "Hemlock",
         "suffix": "MD"
-      },
-      "contact": {
-        "address": {
-          "use": "WP",
-          "street": "200 Corusca Street",
-          "city": "Senate District",
-          "state": "Galactic City",
-          "zip": "GC-500",
-          "county": "Administrative Core",
-          "country": "Coruscant"
-        },
-        "phone": {
-          "use": "WP",
-          "value": "555-555-4321"
-        },
-        "email": {
-          "use": "WP",
-          "value": "dr.hemlock@grmfc.gc.example.com"
-        }
       }
     },
     "patient": {
@@ -109,50 +109,12 @@
           "displayName": "English"
         }
       },
-      "contact": {
-        "address": {
-          "use": "H",
-          "street": "500 Republica, Suite 400",
-          "city": "Senate District",
-          "state": "Galactic City",
-          "zip": "GC-500",
-          "county": "Administrative Core",
-          "country": "Coruscant"
-        },
-        "phone": {
-          "use": "MC",
-          "value": "+1-555-555-9876"
-        },
-        "email": {
-          "use": "WP",
-          "value": "mon.mothma@senate.gr.example.com"
-        }
-      },
       "guardian": {
         "name": {
           "use": null,
           "prefix": null,
           "given": null,
           "family": null
-        },
-        "contact": {
-          "address": {
-            "use": null,
-            "street": null,
-            "city": null,
-            "state": null,
-            "zip": null,
-            "county": null,
-            "country": null
-          },
-          "phone": {
-            "use": null,
-            "value": null
-          },
-          "email": {
-            "use": null,
-            "value": null
-          }
         },
         "relationship": {
           "code": null,
@@ -162,44 +124,16 @@
     },
     "author": {
       "time": "20250215150045-0400",
-      "contact": {
-        "address": {
-          "use": "WP",
-          "street": "500 Republica Medical Plaza, Suite 1000",
-          "city": "Senate District",
-          "state": "Galactic City",
-          "zip": "GC-500",
-          "county": "Administrative Core",
-          "country": "Coruscant"
-        },
-        "phone": {
-          "use": "WP",
-          "value": "+1-888-000-9999"
-        },
-        "fax": {
-          "use": "WP",
-          "value": "+1-888-000-1111"
-        }
+      "organization": {
+        "name": "Grand Republic Medical Facility Clinic"
       },
       "manufacturerModelName": "EpicCore Galactic - Version 45.7",
       "softwareName": "EpicCore Galactic - Version 45.7"
     },
+    "custodian": {
+      "name": "Grand Republic Medical Facility Clinic"
+    },
     "participant":{
-      "contact": {
-        "address": {
-          "use": "WP",
-          "street": "500 Republica, Suite 400",
-          "city": "Senate District",
-          "state": "Galactic City",
-          "zip": "GC-500",
-          "county": "Administrative Core",
-          "country": "Coruscant"
-        },
-        "phone": {
-          "use": "MC",
-          "value": "+1-555-555-9877"
-        }
-      },
       "associatedPerson": {
         "name": {
           "prefix": "Mr",

--- a/assets/mappings/mon-mothma-covid.json
+++ b/assets/mappings/mon-mothma-covid.json
@@ -1,30 +1,10 @@
 {
-  "base": {
-    "document": {
-      "eicr": {
-        "id": "e91bc1e8-2523-4047-a663-1e3e07812948",
-        "setId": "a2e1311c-e39f-48a2-8a2e-c482ab9abd8c",
-        "versionNumber": 1,
-        "title": "Initial Public Health Case Report",
-        "effectiveTime": "20250219001500-0400"
-      },
-      "rr": {
-        "id": "7f8d597f-18fc-4865-a97c-5e1977594f79",
-        "title": "Reportability Response",
-        "effectiveTime": "20250219003615-0400"
-      },
-      "shared": {
-        "confidentialityCode": {
-          "code": "N",
-          "displayName": "Normal"
-        },
-        "languageCode": "en-US"
-      }
-    },
-    "software": {
-      "manufacturerModelName": "EpicCore Galactic - Version 45.7",
-      "softwareName": "EpicCore Galactic - Version 45.7"
-    }
+  "codeSystems": {
+    "LOINC": "2.16.840.1.113883.6.1",
+    "SNOMED-CT": "2.16.840.1.113883.6.96",
+    "NCI Thesaurus": "2.16.840.1.113883.3.26.1.1",
+    "RxNorm": "2.16.840.1.113883.6.88",
+    "CVX": "2.16.840.1.113883.12.292"
   },
   "addresses":{
     "person": {
@@ -60,87 +40,384 @@
       "value": "an.email@grmfc.gc.example.com"
     }
   },
-  "components": {
-    "facility": {
-      "id": "1234567893",
-      "name": "Grand Republic Medical Facility Clinic",
-      "type": {
-        "code": "OF",
-        "displayName": "Outpatient Facility"
+  "facility": {
+    "name": "Grand Republic Medical Facility Clinic"
+  },
+  "provider": {
+    "id": "1234567890",
+    "name": {
+      "prefix": "Dr",
+      "given": "Royce",
+      "family": "Hemlock",
+      "suffix": "MD"
+    }
+  },
+  "patient": {
+    "id": {
+      "mrn": "MRN-00884455",
+      "ssn": "000-65-4321"
+    },
+    "name": {
+      "use": "L",
+      "prefix": "Senator",
+      "given": "Mon",
+      "family": "Mothma"
+    },
+    "demographics": {
+      "gender": {
+        "code": "F",
+        "displayName": "Female"
+      },
+      "birthDate": "19750101",
+      "deceased": false,
+      "race": {
+        "code": "2106-3",
+        "displayName": "White"
+      },
+      "ethnicity": {
+        "code": "2186-5",
+        "displayName": "Not Hispanic or Latino"
+      },
+      "preferredLanguage": {
+        "code": "en",
+        "displayName": "English"
       }
     },
-    "provider": {
-      "id": "1234567890",
+    "guardian": {
       "name": {
-        "prefix": "Dr",
-        "given": "Royce",
-        "family": "Hemlock",
-        "suffix": "MD"
+        "use": null,
+        "prefix": null,
+        "given": null,
+        "family": null
+      },
+      "relationship": {
+        "code": null,
+        "displayName": null
       }
-    },
-    "patient": {
-      "id": {
-        "mrn": "MRN-00884455",
-        "ssn": "000-65-4321"
-      },
-      "name": {
-        "use": "L",
-        "prefix": "Senator",
-        "given": "Mon",
-        "family": "Mothma"
-      },
-      "demographics": {
-        "gender": {
-          "code": "F",
-          "displayName": "Female"
-        },
-        "birthDate": "19750101",
-        "deceased": false,
-        "race": {
-          "code": "2106-3",
-          "displayName": "White"
-        },
-        "ethnicity": {
-          "code": "2186-5",
-          "displayName": "Not Hispanic or Latino"
-        },
-        "preferredLanguage": {
-          "code": "en",
-          "displayName": "English"
-        }
-      },
-      "guardian": {
-        "name": {
-          "use": null,
-          "prefix": null,
-          "given": null,
-          "family": null
-        },
-        "relationship": {
-          "code": null,
-          "displayName": null
-        }
-      }
-    },
-    "author": {
-      "time": "20250215150045-0400",
-      "organization": {
-        "name": "Grand Republic Medical Facility Clinic"
-      },
-      "manufacturerModelName": "EpicCore Galactic - Version 45.7",
-      "softwareName": "EpicCore Galactic - Version 45.7"
-    },
-    "custodian": {
+    }
+  },
+  "author": {
+    "time": "20250215150045-0400",
+    "organization": {
       "name": "Grand Republic Medical Facility Clinic"
     },
-    "participant":{
-      "associatedPerson": {
-        "name": {
-          "prefix": "Mr",
-          "given": "Perrin",
-          "family": "Fertha"
+    "manufacturerModelName": "EpicCore Galactic - Version 45.7",
+    "softwareName": "EpicCore Galactic - Version 45.7"
+  },
+  "custodian": {
+    "name": "Grand Republic Medical Facility Clinic"
+  },
+  "participant":{
+    "associatedPerson": {
+      "name": {
+        "prefix": "Mr",
+        "given": "Perrin",
+        "family": "Fertha"
+      }
+    }
+  },
+  "sections": {
+    "encounters": {
+      "diagnosis": [
+        {
+          "ID": "covid_diagnosis_ref",
+          "code": "840539006",
+          "codeSystemName": "SNOMED-CT",
+          "displayName": "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+        },
+        {
+          "ID": "influenza_diagnosis_ref",
+          "code": "772828001",
+          "codeSystemName": "SNOMED-CT",
+          "displayName": "Influenza caused by Influenza A virus subtype H5N1 (disorder)"
+        }
+      ]
+    },
+    "history_of_present_illness": {
+      "entries": [
+        {
+          "text": "The patient initially presented on February 16, 2025 with difficulty breathing and fever. At follow-up on February 17, patient reported worsening symptoms including cough. Patient disclosed recent travel to a known COVID-19 hot zone from February 8-14, 2025, prompting SARS-CoV-2 testing."
+        },
+        {
+          "text": "On February 21, 2025, test results returned positive for SARS-CoV-2. Patient also reported increased muscle aches, headache, and fatigue. Additional testing revealed concurrent Influenza A infection. Patient diagnosis updated to confirmed COVID-19 and Influenza A co-infection."
+        }
+      ]
+    },
+    "chief_complaint": {
+      "text": "Chief Complaint (the patient's own description): Headache and rash"
+    },
+    "reason_for_visit":  {
+      "text": "fever, cough, exposure to COVID-19 hot zone"
+    },
+    "social_history": {
+      "birth_sex": {
+        "code": "F",
+        "displayName": "Female",
+        "dateValue": "19750101",
+        "dateStr": "01/01/1975"
+      },
+      "occupation": {
+        "code": "11000",
+        "displayName": "Government Officials",
+        "details": "Galactic Senator"
+      },
+      "pregnancy_status": {
+        "code": "60001007",
+        "codeSystemName": "SNOMED-CT",
+        "displayName": "Not pregnant"
+      },
+      "travel_history": {
+        "text": "Recent travel to Chandrila",
+        "start": "20250208",
+        "end": "20250214",
+        "datesStr": "02/08/2025 - 02/14/2025"
+      }
+    },
+    "problems":  {
+      "observations": [
+        {
+          "code": "75325-1",
+          "codeSystemName": "LOINC",
+          "displayName": "SYMPTOM",
+          "translation": {
+            "code": "418799008",
+            "codeSystemName": "SNOMED-CT",
+            "displayName": "SYMPTOM"
+          },
+          "value": {
+            "code": "230145002",
+            "codeSystemName": "SNOMED-CT",
+            "displayName": "Difficulty Breathing (finding)"
+          }
+        },
+        {
+          "code": "75325-1",
+          "codeSystemName": "LOINC",
+          "displayName": "SYMPTOM",
+          "value": {
+            "code": "186747009",
+            "codeSystemName": "SNOMED-CT",
+            "displayName": "Coronavirus infection (disorder)"
+          },
+          "sdtc": {
+            "valueSet": "2.16.840.1.114222.4.11.7508",
+            "valueSetVersion": "20250216"
+          }
+        },
+        {
+          "code": "75323-6",
+          "codeSystemName": "LOINC",
+          "displayName": "Condition",
+          "value": {
+            "code": "840539006",
+            "codeSystemName": "SNOMED-CT",
+            "displayName": "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+          },
+          "sdtc": {
+            "valueSet": "2.16.840.1.114222.4.11.7508",
+            "valueSetVersion": "20250216"
+          }
+        },
+        {
+          "code": "75323-6",
+          "codeSystemName": "LOINC",
+          "displayName": "Condition",
+          "value": {
+            "code": "719865001",
+            "codeSystemName": "SNOMED-CT",
+            "displayName": "Influenza A virus infection (disorder)"
+          },
+          "sdtc": {
+            "valueSet": "2.16.840.1.114222.4.11.7508",
+            "valueSetVersion": "20250216"
+          }
+        }
+      ]
+    },
+    "medications_administered": [
+      {
+        "route": {
+          "code": "C38288",
+          "codeSystemName": "NCI Thesaurus",
+          "displayName": "ORAL"
+        },
+        "doseQuantity": {
+          "value": 1,
+          "unit": "g"
+        },
+        "manufacturedMaterial": {
+          "code": "248656",
+          "codeSystemName": "RxNorm",
+          "displayName": "Azithromycin 500 MG Oral Tablet"
+        },
+        "entryRelationships": [
+          {
+            "type": "observations/therapeutic-response",
+            "typeCode": "CAUS",
+            "value": {
+              "code": "268910001",
+              "codeSystemName": "SNOMED-CT",
+              "displayName": "Patient's condition improved (finding)"
+            }
+          }
+        ]
+      }
+    ],
+    "results": [
+      {
+        "code": "94310-0",
+        "codeSystemName": "LOINC",
+        "displayName": "SARS-like Coronavirus N gene [Presence] in Unspecified specimen by NAA with probe detection",
+        "value": {
+          "code": "260373001",
+          "codeSystemName": "SNOMED-CT",
+          "displayName": "Detected (qualifier value)"
+        },
+        "sdtc": {
+          "valueSet": "2.16.840.1.114222.4.11.7508",
+          "valueSetVersion": "20250216"
+        }
+      },
+      {
+        "code": "34487-9",
+        "codeSystemName": "LOINC",
+        "displayName": "Influenza virus A RNA [Presence] in Respiratory specimen by NAA with probe detection",
+        "value": {
+          "code": "260373001",
+          "codeSystemName": "SNOMED-CT",
+          "displayName": "Detected (qualifier value)"
         }
       }
+    ],
+    "immunizations": {
+      "activities": [
+        {
+          "manufacturedMaterial": {
+            "code": "106",
+            "displayName": "diphtheria, tetanus toxoids and acellular pertussis vaccine, 5 pertussis antigens"
+          }
+        },
+        {
+          "manufacturedMaterial": {
+            "code": "24",
+            "codeSystemName": "CVX",
+            "displayName": "anthrax vaccine"
+          },
+          "sdtc": {
+            "valueSet": "2.16.840.1.114222.4.11.7508",
+            "valueSetVersion": "2020-11-13"
+          }
+        }
+      ],
+      "patientAssertion": {
+        "code": "Y",
+        "displayName": "Yes"
+      }
+    },
+    "vital_signs": {
+      "systolic": 120,
+      "diastolic": 80,
+      "pulse": 80,
+      "temp": 99.0,
+      "respiratoryRate": 18,
+      "heightStr": "5'7 (67 inches)",
+      "height": 67,
+      "weight": 160.0,
+      "bmi": 25.1,
+      "spo": 98
+    },
+    "plan_of_treatment": {
+      "entries": [
+        {
+          "type": "observations/planned",
+          "code": "94500-6",
+          "codeSystemName": "LOINC",
+          "displayName": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection",
+          "sdtc": {
+            "valueSet": "2.16.840.1.114222.4.11.7508",
+            "valueSetVersion": "20250216"
+          }
+        },
+        {
+          "type": "observations/planned",
+          "code": "25836-8",
+          "codeSystemName": "LOINC",
+          "displayName": "Influenza virus A RNA panel",
+          "sdtc": {
+            "valueSet": "2.16.840.1.114222.4.11.7508",
+            "valueSetVersion": "20250216"
+          }
+        },
+        {
+          "type": "activities/medication-activity",
+          "route": {
+            "code": "47625008",
+            "codeSystemName": "SNOMED-CT",
+            "displayName": "Intravenous route"
+          },
+          "doseQuantity": {
+            "value": 100,
+            "unit": "mg"
+          },
+          "manufacturedMaterial": {
+            "code": "2284960",
+            "codeSystemName": "RxNorm",
+            "displayName": "remdesivir 100 MG Injection",
+            "originalText": "Remdesivir 100mg IV daily for 5 days"
+          },
+          "entryRelationships": [
+            {
+              "type": "observations/indication",
+              "typeCode": "RSON",
+              "value": {
+                "code": "840539006",
+                "codeSystemName": "SNOMED-CT",
+                "displayName": "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
+              }
+            }
+          ]
+        },
+        {
+          "type": "activities/medication-activity",
+          "route": {
+            "code": "26643006",
+            "codeSystemName": "SNOMED-CT",
+            "displayName": "Oral route"
+          },
+          "doseQuantity": {
+            "value": 1,
+            "unit": "capsule"
+          },
+          "manufacturedMaterial": {
+            "code": "371005",
+            "codeSystemName": "RxNorm",
+            "displayName": "Oseltamivir 75 MG Oral Capsule",
+            "originalText": "Oseltamivir (Tamiflu) 75mg capsule PO twice daily for 5 days"
+          },
+          "entryRelationships": [
+            {
+              "type": "observations/indication",
+              "typeCode": "RSON",
+              "value": {
+                "code": "772828001",
+                "codeSystemName": "SNOMED-CT",
+                "displayName": "Influenza caused by Influenza A virus subtype H5N1 (disorder)"
+              }
+            }
+          ]
+        },
+        {
+          "type": "encounters/planned",
+          "code": "270427003",
+          "codeSystemName": "SNOMED-CT",
+          "displayName": "Patient-initiated encounter",
+          "participantRole": {
+            "code": "1184-0",
+            "displayName": "Telemedicine"
+          },
+          "text": "Follow-up telehealth visit in 3 days to assess response to treatment"
+        }
+      ]
     }
   },
   "patterns": {

--- a/assets/mappings/mon-mothma-covid.json
+++ b/assets/mappings/mon-mothma-covid.json
@@ -51,7 +51,6 @@
     "name": "Grand Republic Medical Facility Clinic"
   },
   "provider": {
-    "id": "1234567890",
     "name": {
       "prefix": "Dr",
       "given": "Royce",
@@ -205,10 +204,6 @@
             "code": "186747009",
             "codeSystemName": "SNOMED-CT",
             "displayName": "Coronavirus infection (disorder)"
-          },
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
           }
         },
         {
@@ -219,10 +214,6 @@
             "code": "840539006",
             "codeSystemName": "SNOMED-CT",
             "displayName": "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
-          },
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
           }
         },
         {
@@ -233,10 +224,6 @@
             "code": "719865001",
             "codeSystemName": "SNOMED-CT",
             "displayName": "Influenza A virus infection (disorder)"
-          },
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
           }
         }
       ]
@@ -285,10 +272,6 @@
               "code": "260373001",
               "codeSystemName": "SNOMED-CT",
               "displayName": "Detected (qualifier value)"
-            },
-            "sdtc": {
-              "valueSet": "2.16.840.1.114222.4.11.7508",
-              "valueSetVersion": "20250216"
             }
           }
         ]
@@ -449,10 +432,6 @@
             "code": "24",
             "codeSystemName": "CVX",
             "displayName": "anthrax vaccine"
-          },
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "2020-11-13"
           }
         }
       ],
@@ -479,21 +458,13 @@
           "type": "observations/planned",
           "code": "94500-6",
           "codeSystemName": "LOINC",
-          "displayName": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection",
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
-          }
+          "displayName": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"
         },
         {
           "type": "observations/planned",
           "code": "25836-8",
           "codeSystemName": "LOINC",
-          "displayName": "Influenza virus A RNA panel",
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
-          }
+          "displayName": "Influenza virus A RNA panel"
         },
         {
           "type": "activities/medication-activity",

--- a/assets/mappings/mon-mothma-large.json
+++ b/assets/mappings/mon-mothma-large.json
@@ -1,13 +1,19 @@
 {
   "config": {
-    "lab_results_repetitions": 2
+    "lab_results_repetitions": 100,
+    "encounters_diagnosis_repetitions": 100,
+    "history_of_present_illness_repetitions": 100,
+    "problems_obs_repetitions": 100,
+    "medications_administered_repetitions": 100,
+    "immunization_activities_repetitions": 100,
+    "plan_of_treatment_repetitions": 100
   },
   "base": {
     "setId": {
       "extension": "8d86218e-0fea-11eb-8216-a80388425cfb",
       "root": "1.2.840.114350.1.13.380.3.7.1.1"
     },
-    "version": 4
+    "version": 5
   },
   "codeSystems": {
     "LOINC": "2.16.840.1.113883.6.1",
@@ -54,7 +60,6 @@
     "name": "Grand Republic Medical Facility Clinic"
   },
   "provider": {
-    "id": "1234567890",
     "name": {
       "prefix": "Dr",
       "given": "Royce",
@@ -208,10 +213,6 @@
             "code": "186747009",
             "codeSystemName": "SNOMED-CT",
             "displayName": "Coronavirus infection (disorder)"
-          },
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
           }
         },
         {
@@ -222,10 +223,6 @@
             "code": "840539006",
             "codeSystemName": "SNOMED-CT",
             "displayName": "Disease caused by severe acute respiratory syndrome coronavirus 2 (disorder)"
-          },
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
           }
         },
         {
@@ -236,10 +233,6 @@
             "code": "719865001",
             "codeSystemName": "SNOMED-CT",
             "displayName": "Influenza A virus infection (disorder)"
-          },
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
           }
         }
       ]
@@ -288,10 +281,6 @@
               "code": "260373001",
               "codeSystemName": "SNOMED-CT",
               "displayName": "Detected (qualifier value)"
-            },
-            "sdtc": {
-              "valueSet": "2.16.840.1.114222.4.11.7508",
-              "valueSetVersion": "20250216"
             }
           }
         ]
@@ -452,10 +441,6 @@
             "code": "24",
             "codeSystemName": "CVX",
             "displayName": "anthrax vaccine"
-          },
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "2020-11-13"
           }
         }
       ],
@@ -482,21 +467,13 @@
           "type": "observations/planned",
           "code": "94500-6",
           "codeSystemName": "LOINC",
-          "displayName": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection",
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
-          }
+          "displayName": "SARS-CoV-2 (COVID-19) RNA panel - Respiratory specimen by NAA with probe detection"
         },
         {
           "type": "observations/planned",
           "code": "25836-8",
           "codeSystemName": "LOINC",
-          "displayName": "Influenza virus A RNA panel",
-          "sdtc": {
-            "valueSet": "2.16.840.1.114222.4.11.7508",
-            "valueSetVersion": "20250216"
-          }
+          "displayName": "Influenza virus A RNA panel"
         },
         {
           "type": "activities/medication-activity",

--- a/assets/mappings/mon-mothma-large.json
+++ b/assets/mappings/mon-mothma-large.json
@@ -1,4 +1,7 @@
 {
+  "config": {
+    "lab_results_repetitions": 2
+  },
   "base": {
     "setId": {
       "extension": "8d86218e-0fea-11eb-8216-a80388425cfb",

--- a/assets/templates/activities/immunization-activity.xml.j2
+++ b/assets/templates/activities/immunization-activity.xml.j2
@@ -34,11 +34,7 @@
               {%- else -%}
               codeSystem="2.16.840.1.113883.12.292"
               {%- endif %}
-              displayName="{{ immunization_activity.manufacturedMaterial.displayName }}"
-              {% if immunization_activity.sdtc -%}
-              sdtc:valueSet="{{ immunization_activity.sdtc.valueSet }}" sdtc:valueSetVersion="{{ immunization_activity.sdtc.valueSetVersion }}"
-              {% endif -%}
-          />
+              displayName="{{ immunization_activity.manufacturedMaterial.displayName }}" />
           <lotNumberText nullFlavor="NI" />
         </manufacturedMaterial>
       </manufacturedProduct>

--- a/assets/templates/activities/immunization-activity.xml.j2
+++ b/assets/templates/activities/immunization-activity.xml.j2
@@ -1,0 +1,48 @@
+{% macro render_immunization_activity(immunization_activity, codeSystems) %}
+<entry>
+  <substanceAdministration classCode="SBADM" moodCode="EVN"
+    negationInd="false">
+    <!-- [C-CDA 2.1] Immunization Activity (V3) -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.52"
+      extension="2015-08-01" />
+    <id root="{{ uuid() }}" />
+    <statusCode code="completed" />
+    <effectiveTime value="20201107" />
+    {% if immunization_activity.route -%}
+    <routeCode code="{{ immunization_activity.route.code }}" codeSystem="{{ codeSystems[immunization_activity.route.codeSystemName|trim] }}"
+        codeSystemName="{{ immunization_activity.route.codeSystemName }}" displayName="{{ immunization_activity.route.displayName }}" />
+    {% else -%}
+    <routeCode nullFlavor="NI" />
+    {% endif -%}
+    {% if immunization_activity.doseQuantity -%}
+    <doseQuantity value="{{ immunization_activity.doseQuantity.value }}" unit="{{ immunization_activity.doseQuantity.unit }}" />
+    {% else -%}
+    <doseQuantity nullFlavor="NI" />
+    {% endif -%}
+    <consumable>
+      <manufacturedProduct classCode="MANU">
+        <!-- [C-CDA R2.1] Immunization Medication Information (V3) -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.54"
+          extension="2014-06-09" />
+        {#- (TODO: is his needed?) <!-- [eICR R2 STU2] Initial Case Report Trigger Code Problem Observation (V2) --> -#}
+        {#- <templateId root="2.16.840.1.113883.10.20.15.2.3.38" extension="2019-04-01" /> #}
+        <manufacturedMaterial>
+          <code code="{{ immunization_activity.manufacturedMaterial.code }}"
+              {% if immunization_activity.manufacturedMaterial.codeSystemName -%}
+              codeSystem="{{ codeSystems[immunization_activity.manufacturedMaterial.codeSystemName|trim] }}"
+              codeSystemName="{{ immunization_activity.manufacturedMaterial.codeSystemName }}"
+              {%- else -%}
+              codeSystem="2.16.840.1.113883.12.292"
+              {%- endif %}
+              displayName="{{ immunization_activity.manufacturedMaterial.displayName }}"
+              {% if immunization_activity.sdtc -%}
+              sdtc:valueSet="{{ immunization_activity.sdtc.valueSet }}" sdtc:valueSetVersion="{{ immunization_activity.sdtc.valueSetVersion }}"
+              {% endif -%}
+          />
+          <lotNumberText nullFlavor="NI" />
+        </manufacturedMaterial>
+      </manufacturedProduct>
+    </consumable>
+  </substanceAdministration>
+</entry>
+{%- endmacro %}

--- a/assets/templates/activities/immunization-activity.xml.j2
+++ b/assets/templates/activities/immunization-activity.xml.j2
@@ -1,4 +1,4 @@
-{% macro render_immunization_activity(immunization_activity, codeSystems) %}
+{% macro render_immunization_activity(immunization_activity) %}
 <entry>
   <substanceAdministration classCode="SBADM" moodCode="EVN"
     negationInd="false">

--- a/assets/templates/activities/medication-activity.xml.j2
+++ b/assets/templates/activities/medication-activity.xml.j2
@@ -1,0 +1,53 @@
+{%- from "observations/therapeutic-response.xml.j2" import render_therapeutic_response_obs -%}
+{%- from "observations/indication.xml.j2" import render_indication_obs -%}
+{% macro render_medication_activity(medication_activity, codeSystems) %}
+<substanceAdministration classCode="SBADM" moodCode="EVN">
+  <!-- [C-CDA R1.1] Medication Activity -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.16" />
+  <!-- [C-CDA R2.0] Medication Activity (V2) -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.16"
+    extension="2014-06-09" />
+  <id root="{{ uuid() }}" />
+  {#- TODO: Should support status code and effecti times here? #}
+  <statusCode code="completed" />
+  <effectiveTime value="202011071159-0700" />
+  <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true"
+    operator="A">
+    <period value="12" unit="h" />
+  </effectiveTime>
+  <routeCode code="{{ medication_activity.route.code }}" codeSystem="{{ codeSystems[medication_activity.route.codeSystemName|trim] }}"
+    codeSystemName="{{ medication_activity.route.codeSystemName }}" displayName="{{ medication_activity.route.displayName }}" />
+  <doseQuantity value="{{ medication_activity.doseQuantity.value }}" unit="{{ medication_activity.doseQuantity.unit }}" />
+  <consumable>
+    <manufacturedProduct classCode="MANU">
+      <!-- [C-CDA R2.0] Medication Information (V2) -->
+      <templateId root="2.16.840.1.113883.10.20.22.4.23" extension="2014-06-09" />
+      {#- (TODO: is this needed?) <!-- [eICR R2 STU2] Initial Case Report Trigger Code Medication Information --> -#}
+      {#- <templateId root="2.16.840.1.113883.10.20.15.2.3.36" extension="2019-04-01" /> #}
+      <id root="{{ uuid() }}" />
+      <manufacturedMaterial>
+        <code code="{{ medication_activity.manufacturedMaterial.code }}" codeSystem="{{ codeSystems[medication_activity.manufacturedMaterial.codeSystemName|trim] }}"
+          codeSystemName="{{ medication_activity.manufacturedMaterial.codeSystemName }}"
+          displayName="{{ medication_activity.manufacturedMaterial.displayName }}"
+          {% if medication_activity.sdtc -%}
+          sdtc:valueSet="{{ medication_activity.sdtc.valueSet }}" sdtc:valueSetVersion="{{ medication_activity.sdtc.valueSetVersion }}"
+          {% endif -%}
+          >
+          {% if medication_activity.manufacturedMaterial.originalText -%}
+          <originalText>{{ medication_activity.manufacturedMaterial.originalText }}</originalText>
+          {%- endif %}
+        </code>
+      </manufacturedMaterial>
+    </manufacturedProduct>
+  </consumable>
+  {%- for entry in medication_activity.entryRelationships %}
+  <entryRelationship typeCode="{{ entry.typeCode }}">
+    {%- if entry.type == "observations/therapeutic-response" -%}
+    {{ render_therapeutic_response_obs(entry, codeSystems) | indent(4, True) }}
+    {%- elif entry.type == "observations/indication" -%}
+    {{ render_indication_obs(entry, codeSystems) | indent(4, True) }}
+    {%- endif %}
+  </entryRelationship>
+  {%- endfor %}
+</substanceAdministration>
+{%- endmacro %}

--- a/assets/templates/activities/medication-activity.xml.j2
+++ b/assets/templates/activities/medication-activity.xml.j2
@@ -1,6 +1,6 @@
 {%- from "observations/therapeutic-response.xml.j2" import render_therapeutic_response_obs -%}
 {%- from "observations/indication.xml.j2" import render_indication_obs -%}
-{% macro render_medication_activity(medication_activity, codeSystems) %}
+{% macro render_medication_activity(medication_activity) %}
 <substanceAdministration classCode="SBADM" moodCode="EVN">
   <!-- [C-CDA R1.1] Medication Activity -->
   <templateId root="2.16.840.1.113883.10.20.22.4.16" />
@@ -43,9 +43,9 @@
   {%- for entry in medication_activity.entryRelationships %}
   <entryRelationship typeCode="{{ entry.typeCode }}">
     {%- if entry.type == "observations/therapeutic-response" -%}
-    {{ render_therapeutic_response_obs(entry, codeSystems) | indent(4, True) }}
+    {{ render_therapeutic_response_obs(entry) | indent(4, True) }}
     {%- elif entry.type == "observations/indication" -%}
-    {{ render_indication_obs(entry, codeSystems) | indent(4, True) }}
+    {{ render_indication_obs(entry) | indent(4, True) }}
     {%- endif %}
   </entryRelationship>
   {%- endfor %}

--- a/assets/templates/activities/medication-activity.xml.j2
+++ b/assets/templates/activities/medication-activity.xml.j2
@@ -28,12 +28,8 @@
       <manufacturedMaterial>
         <code code="{{ medication_activity.manufacturedMaterial.code }}" codeSystem="{{ codeSystems[medication_activity.manufacturedMaterial.codeSystemName|trim] }}"
           codeSystemName="{{ medication_activity.manufacturedMaterial.codeSystemName }}"
-          displayName="{{ medication_activity.manufacturedMaterial.displayName }}"
-          {% if medication_activity.sdtc -%}
-          sdtc:valueSet="{{ medication_activity.sdtc.valueSet }}" sdtc:valueSetVersion="{{ medication_activity.sdtc.valueSetVersion }}"
-          {% endif -%}
-          >
-          {% if medication_activity.manufacturedMaterial.originalText -%}
+          displayName="{{ medication_activity.manufacturedMaterial.displayName }}" >
+          {%- if medication_activity.manufacturedMaterial.originalText %}
           <originalText>{{ medication_activity.manufacturedMaterial.originalText }}</originalText>
           {%- endif %}
         </code>

--- a/assets/templates/components/author.xml.j2
+++ b/assets/templates/components/author.xml.j2
@@ -1,26 +1,31 @@
 {#- author template for eICR/RR documents -#}
-{% if author %}<author>
-    {% if author.time %}<time value="{{ author.time }}" />{% endif %}
+{%- from "components/macros.xml.j2" import format_address, format_telecom -%}
+  <author>
+    {% if components.author.time %}<time value="{{ components.author.time }}" />{% endif %}
     <assignedAuthor>
-        <id root="2.16.840.1.113883.3.72.5.20" />
-        {% if author.contact.address %}<addr use="{% if author.contact.address.use %}{{ author.contact.address.use }}{% else %}WP{% endif %}">{% endif %}
-            {% if author.contact.address.street %}<streetAddressLine>{{ author.contact.address.street }}</streetAddressLine>{% endif %}
-            {% if author.contact.address.city %}<city>{{ author.contact.address.city }}</city>{% endif %}
-            {% if author.contact.address.state %}<state>{{ author.contact.address.state }}</state>{% endif %}
-            {% if author.contact.address.zip %}<postalCode>{{ author.contact.address.zip }}</postalCode>{% endif %}
-            {% if author.contact.address.county %}<county>{{ author.contact.address.county }}</county>
-            {% endif %}
-            {% if author.contact.address.country %}
-                <country>{{ author.contact.address.country }}</country>
-            {% endif %}
-        </addr>
-        {% if author.contact.phone.value %}
-            <telecom use="{{ author.contact.phone.use }}" value="tel:{{ author.contact.phone.value }}" />
-        {% endif %}
-        {% if author.contact.fax.value %}<telecom use="{{ author.contact.fax.use }}" value="fax:{{ author.contact.fax.value }}" />{% endif %}
-        <assignedAuthoringDevice>
-            {% if author.manufacturerModelName %}<manufacturerModelName>{{ author.manufacturerModelName }}</manufacturerModelName>{% endif %}
-            {% if author.softwareName %} <softwareName>{{ author.softwareName }}</softwareName>{% endif %}
-        </assignedAuthoringDevice>
+      <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+      {{- format_address(addresses.person) | indent(6, True) -}}
+      {{- format_telecom(telecom) | indent(6, True) }}
+      <assignedAuthoringDevice>
+        {% if components.author.manufacturerModelName %}<manufacturerModelName>{{ components.author.manufacturerModelName }}</manufacturerModelName>{% endif %}
+        {% if components.author.softwareName %}<softwareName>{{ components.author.softwareName }}</softwareName>{% endif %}
+      </assignedAuthoringDevice>
+      {% if components.author.assignedPerson %}
+      <assignedPerson>
+        <name>
+          {% if components.author.assignedPerson.prefix %}<prefix>{{ components.author.assignedPerson.prefix }}</prefix>{% endif %}
+          <given>{{ components.author.assignedPerson.given }}</given>
+          <family>{{ components.author.assignedPerson.family }}</family>
+          {% if components.author.assignedPerson.suffix %}<suffix>{{ components.author.assignedPerson.suffix }}</suffix>{% endif %}
+        </name>
+      </assignedPerson>
+      {% endif -%}
+      <representedOrganization>
+        <!-- NPI -->
+        <id extension="1234567893" root="2.16.840.1.113883.4.6" />
+        <name>{{ components.author.organization.name }}</name>
+        {{- format_address(addresses.organization) | indent(8, True) -}}
+        {{- format_telecom(telecom) | indent(8, True) }}
+      </representedOrganization>
     </assignedAuthor>
-</author>{% endif %}
+  </author>

--- a/assets/templates/components/author.xml.j2
+++ b/assets/templates/components/author.xml.j2
@@ -1,29 +1,24 @@
 {#- author template for eICR/RR documents -#}
-{%- from "components/macros.xml.j2" import format_address, format_telecom -%}
+{%- from "components/macros.xml.j2" import format_address, format_telecom, format_name -%}
   <author>
-    {% if components.author.time %}<time value="{{ components.author.time }}" />{% endif %}
+    {% if author.time %}<time value="{{ author.time }}" />{% endif %}
     <assignedAuthor>
       <id extension="1234567890" root="2.16.840.1.113883.4.6" />
       {{- format_address(addresses.person) | indent(6, True) -}}
       {{- format_telecom(telecom) | indent(6, True) }}
       <assignedAuthoringDevice>
-        {% if components.author.manufacturerModelName %}<manufacturerModelName>{{ components.author.manufacturerModelName }}</manufacturerModelName>{% endif %}
-        {% if components.author.softwareName %}<softwareName>{{ components.author.softwareName }}</softwareName>{% endif %}
+        {% if author.manufacturerModelName %}<manufacturerModelName>{{ author.manufacturerModelName }}</manufacturerModelName>{% endif %}
+        {% if author.softwareName %}<softwareName>{{ author.softwareName }}</softwareName>{% endif %}
       </assignedAuthoringDevice>
-      {% if components.author.assignedPerson %}
+      {% if author.assignedPerson %}
       <assignedPerson>
-        <name>
-          {% if components.author.assignedPerson.prefix %}<prefix>{{ components.author.assignedPerson.prefix }}</prefix>{% endif %}
-          <given>{{ components.author.assignedPerson.given }}</given>
-          <family>{{ components.author.assignedPerson.family }}</family>
-          {% if components.author.assignedPerson.suffix %}<suffix>{{ components.author.assignedPerson.suffix }}</suffix>{% endif %}
-        </name>
+        {{- format_name(author.assignedPerson) | indent(12, True) }}
       </assignedPerson>
       {% endif -%}
       <representedOrganization>
         <!-- NPI -->
         <id extension="1234567893" root="2.16.840.1.113883.4.6" />
-        <name>{{ components.author.organization.name }}</name>
+        <name>{{ author.organization.name }}</name>
         {{- format_address(addresses.organization) | indent(8, True) -}}
         {{- format_telecom(telecom) | indent(8, True) }}
       </representedOrganization>

--- a/assets/templates/components/base.xml.j2
+++ b/assets/templates/components/base.xml.j2
@@ -19,9 +19,18 @@
   <effectiveTime value="{{ timestamp() }}" />
   <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal" />
   <languageCode code="en-US" />
-  <setId extension="8d86218e-0fea-11eb-8216-a80388425cfb"
+  {%- if base.setId %}
+  <setId extension="{{ base.setId.extension }}"
+  root="{{ base.setId.root }}" />
+  {%- else -%}
+  <setId extension="{{ uuid() }}"
   root="1.2.840.114350.1.13.380.3.7.1.1" />
-  <versionNumber value="3" />
+  {%- endif %}
+  {%- if base.version %}
+  <versionNumber value="{{ base.version }}" />
+  {%- else -%}
+  <versionNumber value="1" />
+  {%- endif %}
 
   <!-- recordTarget: The patient -->
   {%- include 'components/patient.xml.j2' %}
@@ -38,9 +47,9 @@
   the case. -->
   {% include 'components/componentOf.xml.j2' %}
 
-  <!-- first component holds the structredBody -->
+  <!-- first component holds the structuredBody -->
   <component>
-    <!-- structredBody contains all of the clinical sections of the eICR -->
+    <!-- structuredBody contains all of the clinical sections of the eICR -->
     <structuredBody>
       <!-- Encounters section -->
       <component>
@@ -95,6 +104,27 @@
       <!-- Plan of Care/Treatment Section -->
       <component>
       {%- include 'sections/plan-of-treatment.xml.j2' %}
+      </component>
+
+      {#- TODO: The sections below have not been fully templated yet #}
+      <!-- Pregnancy Section -->
+      <component>
+      {%- include 'sections/pregnancy.xml.j2' %}
+      </component>
+
+      <!-- Procedures Section -->
+      <component>
+      {%- include 'sections/procedures.xml.j2' %}
+      </component>
+
+      <!-- Emergency Outbreak Information -->
+      <component>
+      {%- include 'sections/emergency-outbreak.xml.j2' %}
+      </component>
+
+      <!-- Reportability Response Information -->
+      <component>
+      {%- include 'sections/reportability-response.xml.j2' %}
       </component>
     </structuredBody>
   </component>

--- a/assets/templates/components/base.xml.j2
+++ b/assets/templates/components/base.xml.j2
@@ -36,5 +36,66 @@
 
   <!-- componentOf: contains the encompassingEncouter and the provider and facility information for
   the case. -->
+  {% include 'components/componentOf.xml.j2' %}
 
+  <!-- first component holds the structredBody -->
+  <component>
+    <!-- structredBody contains all of the clinical sections of the eICR -->
+    <structuredBody>
+      <!-- Encounters section -->
+      <component>
+      {%- include 'sections/encounters.xml.j2' %}
+      </component>
+
+      <!-- History of Present Illness Section -->
+      <component>
+      {%- include 'sections/history-of-present-illness.xml.j2' %}
+      </component>
+
+      <!-- Chief Complaint Section -->
+      <component>
+      {%- include 'sections/chief-complaint.xml.j2' %}
+      </component>
+
+      <!-- Reason for visit Section -->
+      <component>
+      {%- include 'sections/reason-for-visit.xml.j2' %}
+      </component>
+
+       <!-- Social History Section -->
+      <component>
+      {%- include 'sections/social-history.xml.j2' %}
+      </component>
+
+      <!-- Problems Section -->
+      <component>
+      {%- include 'sections/problems-section.xml.j2' %}
+      </component>
+
+      <!-- Medications Administered Section -->
+      <component>
+      {%- include 'sections/medications-administered.xml.j2' %}
+      </component>
+
+      <!-- Results Section -->
+      <component>
+      {%- include 'sections/results.xml.j2' %}
+      </component>
+
+      <!-- Immunizations Section -->
+      <component>
+      {%- include 'sections/immunizations.xml.j2' %}
+      </component>
+
+      <!-- Vital Signs Section -->
+      <component>
+      {%- include 'sections/vital-signs.xml.j2' %}
+      </component>
+
+      <!-- Plan of Care/Treatment Section -->
+      <component>
+      {%- include 'sections/plan-of-treatment.xml.j2' %}
+      </component>
+    </structuredBody>
+  </component>
 </ClinicalDocument>

--- a/assets/templates/components/base.xml.j2
+++ b/assets/templates/components/base.xml.j2
@@ -1,0 +1,40 @@
+<ClinicalDocument xmlns="{{ nsmap[None] }}" xmlns:cda="{{ nsmap[None] }}" xmlns:sdtc="{{ nsmap['sdtc'] }}"
+  xmlns:voc="{{ nsmap['voc'] }}"
+  xmlns:xsi="{{ nsmap['xsi'] }}"
+  xsi:schemaLocation="{{ nsmap['schema_location'] }}">
+  <realmCode code="US" />
+  <!-- [C-CDA R1.1] US Realm Header-->
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3" />
+  <!-- [C-CDA R2.1] US Realm Header (V3) -->
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" />
+  <!-- [eICR R2 STU1.1] Initial Public Health Case Report Document (eICR) (V2) -->
+  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.1.1" />
+  <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2" />
+  <!-- Globally unique document ID (extension) is scoped by vendor/software-->
+  <id root="{{ uuid() }}" />
+  <!-- Document Code-->
+  <code code="55751-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+  displayName="Public Health Case Report" />
+  <title>Initial Public Health Case Report</title>
+  <effectiveTime value="{{ timestamp() }}" />
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25" displayName="Normal" />
+  <languageCode code="en-US" />
+  <setId extension="8d86218e-0fea-11eb-8216-a80388425cfb"
+  root="1.2.840.114350.1.13.380.3.7.1.1" />
+  <versionNumber value="3" />
+
+  <!-- recordTarget: The patient -->
+  {%- include 'components/patient.xml.j2' %}
+
+  <!-- Author/authenticator may be software or may be a provider such as "infection control
+  professional"-->
+  {% include 'components/author.xml.j2' %}
+
+  <!-- Custodian: organization or entity that is responsible for maintaining and safeguarding the
+  document -->
+  {% include 'components/custodian.xml.j2' %}
+
+  <!-- componentOf: contains the encompassingEncouter and the provider and facility information for
+  the case. -->
+
+</ClinicalDocument>

--- a/assets/templates/components/componentOf.xml.j2
+++ b/assets/templates/components/componentOf.xml.j2
@@ -1,5 +1,5 @@
-{# TODO - THIS! #}
-<componentOf>
+{%- from "components/macros.xml.j2" import format_address, format_telecom, format_name -%}
+  <componentOf>
     <encompassingEncounter>
       <!-- encounter ID-->
       <id extension="9937015" root="2.16.840.1.113883.19" />
@@ -14,38 +14,17 @@
         <assignedEntity>
           <!-- Provider ID (NPI) -->
           <id extension="1234567890" root="2.16.840.1.113883.4.6" />
-          <addr use="H">
-            <streetAddressLine>200 Corusca Street</streetAddressLine>
-            <city>Senate District</city>
-            <state>Galactic City</state>
-            <postalCode>GC-500</postalCode>
-            <county>Administrative Core</county>
-            <country>Coruscant</country>
-          </addr>
-          <telecom use="WP" value="tel:+1-555-777-0123" />
-          <telecom use="WP" value="fax:+1-555-777-0987" />
-          <telecom use="WP" value="mailto:dr.hemlock@grmfc.gc.example.com" />
+          {{- format_address(addresses.person) | indent(10, True) -}}
+          {{- format_telecom(telecom) | indent(10, True) }}
           <assignedPerson>
-            <name>
-              <prefix>Dr</prefix>
-              <given>Royce</given>
-              <family>Hemlock</family>
-              <suffix>MD</suffix>
-            </name>
+            {{- format_name(provider.name) | indent(12, True) }}
           </assignedPerson>
           <representedOrganization>
             <!-- Represented Organization-->
             <id extension="1234567893" root="2.16.840.1.113883.4.6" />
             <!-- Provider Facility/Office Name-->
-            <name>Grand Republic Medical Facility Clinic</name>
-            <addr use="WP">
-              <streetAddressLine>500 Republica Medical Plaza, Suite 1000</streetAddressLine>
-              <city>Senate District</city>
-              <state>Galactic City</state>
-              <postalCode>GC-500</postalCode>
-              <county>Administrative Core</county>
-              <country>Coruscant</country>
-            </addr>
+            <name>{{ facility.name }}</name>
+            {{- format_address(addresses.organization) | indent(12, True) }}
           </representedOrganization>
         </assignedEntity>
       </responsibleParty>
@@ -58,28 +37,13 @@
           <code code="OF" codeSystem="2.16.840.1.113883.5.111"
             codeSystemName="HL7RoleCode" displayName="Outpatient Facility" />
           <location>
-            <addr use="WP">
-              <streetAddressLine>500 Republica Medical Plaza, Suite 1000</streetAddressLine>
-              <city>Senate District</city>
-              <state>Galactic City</state>
-              <postalCode>GC-500</postalCode>
-              <county>Administrative Core</county>
-              <country>Coruscant</country>
-            </addr>
+            {{- format_address(addresses.organization) | indent(12, True) }}
           </location>
           <serviceProviderOrganization>
             <!-- Provider Facility/Office Name-->
-            <name>Grand Republic Medical Facility Clinic</name>
-            <telecom use="WP" value="tel:+1-888-000-9999" />
-            <telecom use="WP" value="fax:+1-888-000-1111" />
-            <addr use="WP">
-              <streetAddressLine>500 Republica Medical Plaza, Suite 1000</streetAddressLine>
-              <city>Senate District</city>
-              <state>Galactic City</state>
-              <postalCode>GC-500</postalCode>
-              <county>Administrative Core</county>
-              <country>Coruscant</country>
-            </addr>
+            <name>{{ facility.name }}</name>
+            {{- format_address(addresses.organization) | indent(12, True) -}}
+            {{- format_telecom(telecom) | indent(12, True) }}
           </serviceProviderOrganization>
         </healthCareFacility>
       </location>

--- a/assets/templates/components/componentOf.xml.j2
+++ b/assets/templates/components/componentOf.xml.j2
@@ -1,0 +1,87 @@
+{# TODO - THIS! #}
+<componentOf>
+    <encompassingEncounter>
+      <!-- encounter ID-->
+      <id extension="9937015" root="2.16.840.1.113883.19" />
+      <code code="AMB" codeSystem="2.16.840.1.113883.5.4"
+        codeSystemName="HL7 ActEncounterCode"
+        displayName="Ambulatory" />
+      <effectiveTime>
+        <low value="20200513" />
+        <high value="20200513" />
+      </effectiveTime>
+      <responsibleParty>
+        <assignedEntity>
+          <!-- Provider ID (NPI) -->
+          <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+          <addr use="H">
+            <streetAddressLine>200 Corusca Street</streetAddressLine>
+            <city>Senate District</city>
+            <state>Galactic City</state>
+            <postalCode>GC-500</postalCode>
+            <county>Administrative Core</county>
+            <country>Coruscant</country>
+          </addr>
+          <telecom use="WP" value="tel:+1-555-777-0123" />
+          <telecom use="WP" value="fax:+1-555-777-0987" />
+          <telecom use="WP" value="mailto:dr.hemlock@grmfc.gc.example.com" />
+          <assignedPerson>
+            <name>
+              <prefix>Dr</prefix>
+              <given>Royce</given>
+              <family>Hemlock</family>
+              <suffix>MD</suffix>
+            </name>
+          </assignedPerson>
+          <representedOrganization>
+            <!-- Represented Organization-->
+            <id extension="1234567893" root="2.16.840.1.113883.4.6" />
+            <!-- Provider Facility/Office Name-->
+            <name>Grand Republic Medical Facility Clinic</name>
+            <addr use="WP">
+              <streetAddressLine>500 Republica Medical Plaza, Suite 1000</streetAddressLine>
+              <city>Senate District</city>
+              <state>Galactic City</state>
+              <postalCode>GC-500</postalCode>
+              <county>Administrative Core</county>
+              <country>Coruscant</country>
+            </addr>
+          </representedOrganization>
+        </assignedEntity>
+      </responsibleParty>
+      <location>
+        <healthCareFacility>
+          <!-- Facility ID (NPI) -->
+          <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+          <!-- Facility location within larger healthcare organization e.g Kaiser Vacaville within
+          Kaiser North-->
+          <code code="OF" codeSystem="2.16.840.1.113883.5.111"
+            codeSystemName="HL7RoleCode" displayName="Outpatient Facility" />
+          <location>
+            <addr use="WP">
+              <streetAddressLine>500 Republica Medical Plaza, Suite 1000</streetAddressLine>
+              <city>Senate District</city>
+              <state>Galactic City</state>
+              <postalCode>GC-500</postalCode>
+              <county>Administrative Core</county>
+              <country>Coruscant</country>
+            </addr>
+          </location>
+          <serviceProviderOrganization>
+            <!-- Provider Facility/Office Name-->
+            <name>Grand Republic Medical Facility Clinic</name>
+            <telecom use="WP" value="tel:+1-888-000-9999" />
+            <telecom use="WP" value="fax:+1-888-000-1111" />
+            <addr use="WP">
+              <streetAddressLine>500 Republica Medical Plaza, Suite 1000</streetAddressLine>
+              <city>Senate District</city>
+              <state>Galactic City</state>
+              <postalCode>GC-500</postalCode>
+              <county>Administrative Core</county>
+              <country>Coruscant</country>
+            </addr>
+          </serviceProviderOrganization>
+        </healthCareFacility>
+      </location>
+    </encompassingEncounter>
+  </componentOf>

--- a/assets/templates/components/custodian.xml.j2
+++ b/assets/templates/components/custodian.xml.j2
@@ -1,26 +1,12 @@
-{#- custodian template for custodian in an eICR document -#}
-{%- macro format_address(addr) %}
-    <addr use="{{ addr.use }}">
-    {%- if addr.street %}<streetAddressLine>{{ addr.street }}</streetAddressLine>{%- endif %}
-        {%- if addr.city %}<city>{{ addr.city }}</city>{%- endif %}
-            {%- if addr.state %}<state>{{ addr.state }}</state>{%- endif %}
-                {%- if addr.zip %}<postalCode>{{ addr.zip }}</postalCode>{%- endif %}
-                    {%- if addr.county %}<county>{{ addr.county }}</county>{%- endif %}
-                        {%- if addr.country %}<country>{{ addr.country }}</country>{%- endif %}
-                            </addr>
-                        {%- endmacro %}
-                        {%- macro format_telecom(phone=None, fax=None) %}
-                            {%- if phone %}<telecom use="{{ phone.use }}" value="tel:{{ phone.value }}" />{%- endif %}
-                                {%- if fax %}<telecom use="{{ fax.use }}" value="fax:{{ fax.value }}" />{%- endif %}
-                                {%- endmacro %}
-                                <custodian xmlns="{{ nsmap[None] }}" xmlns:xsi="{{ nsmap['xsi'] }}">
-                                <assignedCustodian>
-                                <representedCustodianOrganization>
-                                {#- Custodian ID (NPI) -#}
-                                <id extension="{{ facility.id }}" root="2.16.840.1.113883.4.6" />
-                                <name>{{ facility.name }}</name>
-                                {%- if facility.contact %}{{ format_telecom(facility.contact.phone, facility.contact.fax) }}{%- endif %}
-                                    {%- if facility.contact.address %}{{ format_address(facility.contact.address) }}{%- endif %}
-                                        </representedCustodianOrganization>
-                                        </assignedCustodian>
-                                        </custodian>
+{%- from "components/macros.xml.j2" import format_address, format_telecom -%}
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <!-- Custodian ID (NPI) -->
+        <id extension="1234567893" root="2.16.840.1.113883.4.6" />
+        <name>{{ components.custodian.name }}</name>
+        {{- format_address(addresses.organization) | indent(8, True) -}}
+        {{- format_telecom(telecom) | indent(8, True) }}
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>

--- a/assets/templates/components/custodian.xml.j2
+++ b/assets/templates/components/custodian.xml.j2
@@ -4,7 +4,7 @@
       <representedCustodianOrganization>
         <!-- Custodian ID (NPI) -->
         <id extension="1234567893" root="2.16.840.1.113883.4.6" />
-        <name>{{ components.custodian.name }}</name>
+        <name>{{ custodian.name }}</name>
         {{- format_address(addresses.organization) | indent(8, True) -}}
         {{- format_telecom(telecom) | indent(8, True) }}
       </representedCustodianOrganization>

--- a/assets/templates/components/macros.xml.j2
+++ b/assets/templates/components/macros.xml.j2
@@ -1,0 +1,22 @@
+{%- macro format_address(addr) %}
+<addr use="{{ addr.use }}">
+    {% if addr.street %}<streetAddressLine>{{ addr.street }}</streetAddressLine>{% endif %}
+    {% if addr.city %}<city>{{ addr.city }}</city>{% endif %}
+    {% if addr.state %}<state>{{ addr.state }}</state>{% endif %}
+    {% if addr.zip %}<postalCode>{{ addr.zip }}</postalCode>{% endif %}
+    {% if addr.county %}<county>{{ addr.county }}</county>{% endif %}
+    {% if addr.country %}<country>{{ addr.country }}</country>{% endif %}
+</addr>
+{%- endmacro %}
+
+{%- macro format_telecom(telecom) -%}
+{%- if telecom.phone %}
+<telecom use="{{ telecom.phone.use }}" value="tel:{{ telecom.phone.value }}" />
+{%- endif -%}
+{%- if telecom.email %}
+<telecom use="{{ telecom.email.use }}" value="mailto:{{ telecom.email.value }}" />
+{%- endif -%}
+{%- if telecom.fax %}
+<telecom use="{{ telecom.fax.use }}" value="fax:{{ telecom.fax.value }}" />
+{%- endif -%}
+{%- endmacro -%}

--- a/assets/templates/components/macros.xml.j2
+++ b/assets/templates/components/macros.xml.j2
@@ -20,3 +20,16 @@
 <telecom use="{{ telecom.fax.use }}" value="fax:{{ telecom.fax.value }}" />
 {%- endif -%}
 {%- endmacro -%}
+
+{% macro format_name(name) %}
+{% if name.use -%}
+<name use="{{ name.use }}">
+{%- else -%}
+<name>
+{%- endif %}
+  {% if name.prefix %}<prefix>{{ name.prefix }}</prefix>{%- endif %}
+  <given>{{ name.given }}</given>
+  <family>{{ name.family }}</family>
+  {%- if name.suffix %}<suffix>{{ name.suffix }}</suffix>{% endif %}
+</name>
+{%- endmacro %}

--- a/assets/templates/components/patient.xml.j2
+++ b/assets/templates/components/patient.xml.j2
@@ -1,54 +1,46 @@
 {#- patient template for eICR/RR documents -#}
-{% from "components/macros.xml.j2" import format_address, format_telecom %}
+{% from "components/macros.xml.j2" import format_address, format_telecom, format_name %}
   <recordTarget xmlns="{{ nsmap[None] }}" xmlns:sdtc="{{ nsmap['sdtc'] }}" xmlns:xsi="{{ nsmap['xsi'] }}" xmlns:voc="{{ nsmap['voc'] }}">
     <patientRole>
       {#- patient identifiers #}
-      {% if components.patient.id.mrn %}<id root="2.16.840.1.113883.19.5" extension="{{ components.patient.id.mrn }}" />{% endif %}
-      {% if components.patient.id.ssn %}<id root="2.16.840.1.113883.4.1" extension="{{ components.patient.id.ssn }}" />{% endif %}
+      {% if patient.id.mrn %}<id root="2.16.840.1.113883.19.5" extension="{{ patient.id.mrn }}" />{% endif %}
+      {% if patient.id.ssn %}<id root="2.16.840.1.113883.4.1" extension="{{ patient.id.ssn }}" />{% endif %}
       {#- patient address -#}
       {{ format_address(addresses.person) | indent(6, True) }}
       {#- patient contact information -#}
       {{ format_telecom(telecom) | indent(6, True) }}
       <patient>
         {#- patient name -#}
-        {%- if components.patient.name %}
-        <name use="{{ components.patient.name.use }}">
-            {% if components.patient.name.prefix %}<prefix>{{ components.patient.name.prefix }}</prefix>{% endif %}
-            <given>{{ components.patient.name.given }}</given>
-            <family>{{ components.patient.name.family }}</family>
-        </name>
+        {%- if patient.name %}
+        {{- format_name(patient.name) | indent(8, True) }}
         {% endif %}
         {#- demographics -#}
-        <administrativeGenderCode code="{{ components.patient.demographics.gender.code }}" codeSystem="2.16.840.1.113883.5.1" displayName="{{ components.patient.demographics.gender.displayName }}" />
-        <birthTime value="{{ components.patient.demographics.birthDate }}" />
-        {% if components.patient.demographics.deceased is defined -%}
-        <sdtc:deceasedInd value="{{ components.patient.demographics.deceased|lower }}" />
+        <administrativeGenderCode code="{{ patient.demographics.gender.code }}" codeSystem="2.16.840.1.113883.5.1" displayName="{{ patient.demographics.gender.displayName }}" />
+        <birthTime value="{{ patient.demographics.birthDate }}" />
+        {% if patient.demographics.deceased is defined -%}
+        <sdtc:deceasedInd value="{{ patient.demographics.deceased|lower }}" />
         {%- endif %}
-        <raceCode code="{{ components.patient.demographics.race.code }}" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="{{ components.patient.demographics.race.displayName }}" />
-        <ethnicGroupCode code="{{ components.patient.demographics.ethnicity.code }}" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="{{ components.patient.demographics.ethnicity.displayName }}" />
+        <raceCode code="{{ patient.demographics.race.code }}" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="{{ patient.demographics.race.displayName }}" />
+        <ethnicGroupCode code="{{ patient.demographics.ethnicity.code }}" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="{{ patient.demographics.ethnicity.displayName }}" />
         {#- language -#}
-        {% if components.patient.demographics.preferredLanguage %}
+        {% if patient.demographics.preferredLanguage %}
         <languageCommunication>
-            <languageCode code="{{ components.patient.demographics.preferredLanguage.code }}" />
+            <languageCode code="{{ patient.demographics.preferredLanguage.code }}" />
             <preferenceInd value="true" />
         </languageCommunication>
         {%- endif %}
       </patient>
       {#- guardian information (if exists and not null) - TODO: test this section #}
-      {%- if components.patient.guardian and components.patient.guardian.name.given %}
+      {%- if patient.guardian and patient.guardian.name.given %}
       <guardian>
         <guardianPerson>
-          <name use="{{ components.patient.guardian.name.use }}">
-          {%- if components.patient.guardian.name.prefix %}<prefix>{{ components.patient.guardian.name.prefix }}</prefix>{%- endif %}
-          <given>{{ components.patient.guardian.name.given }}</given>
-          <family>{{ components.patient.guardian.name.family }}</family>
-          </name>
+          {{ format_name(patient.guardian.name) | indent(12, True) }}
         </guardianPerson>
           {{ format_address(addresses.person) }}
           {{ format_telecom(telecom) }}
-          {%- if components.patient.guardian.relationship %}
+          {%- if patient.guardian.relationship %}
           <guardianRole>
-          <code code="{{ components.patient.guardian.relationship.code }}" displayName="{{ components.patient.guardian.relationship.displayName }}" />
+          <code code="{{ patient.guardian.relationship.code }}" displayName="{{ patient.guardian.relationship.displayName }}" />
         </guardianRole>
         {%- endif %}
       </guardian>

--- a/assets/templates/components/patient.xml.j2
+++ b/assets/templates/components/patient.xml.j2
@@ -1,70 +1,57 @@
 {#- patient template for eICR/RR documents -#}
-{%- macro format_address(addr) %}
-    <addr use="{{ addr.use }}">
-    {%- if addr.street %}<streetAddressLine>{{ addr.street }}</streetAddressLine>{%- endif %}
-        {%- if addr.city %}<city>{{ addr.city }}</city>{%- endif %}
-            {%- if addr.state %}<state>{{ addr.state }}</state>{%- endif %}
-                {%- if addr.zip %}<postalCode>{{ addr.zip }}</postalCode>{%- endif %}
-                    {%- if addr.county %}<county>{{ addr.county }}</county>{%- endif %}
-                        {%- if addr.country %}<country>{{ addr.country }}</country>{%- endif %}
-                            </addr>
-                        {%- endmacro %}
-                        {%- macro format_telecom(phone=None, email=None) %}
-                            {%- if phone %}<telecom use="{{ phone.use }}" value="tel:{{ phone.value }}" />{%- endif %}
-                                {%- if email %}<telecom use="{{ email.use }}" value="mailto:{{ email.value }}" />{%- endif %}
-                                {%- endmacro %}
-                                <recordTarget xmlns="{{ nsmap[None] }}" xmlns:sdtc="{{ nsmap['sdtc'] }}" xmlns:xsi="{{ nsmap['xsi'] }}" xmlns:voc="{{ nsmap['voc'] }}">
-                                <patientRole>
-                                {#- patient identifiers -#}
-                                {%- if patient.id.mrn %}<id root="2.16.840.1.113883.19.5" extension="{{ patient.id.mrn }}" />{%- endif %}
-                                    {%- if patient.id.ssn %}<id root="2.16.840.1.113883.4.1" extension="{{ patient.id.ssn }}" />{%- endif %}
-                                        {#- patient address -#}
-                                        {%- if patient.contact.address %}{{ format_address(patient.contact.address) }}{%- endif %}
-                                            {#- patient contact information -#}
-                                            {%- if patient.contact %}{{ format_telecom(patient.contact.phone, patient.contact.email) }}{%- endif %}
-                                                <patient>
-                                                {#- patient name -#}
-                                                {%- if patient.name %}
-                                                    <name use="{{ patient.name.use }}">
-                                                    {%- if patient.name.prefix %}<prefix>{{ patient.name.prefix }}</prefix>{%- endif %}
-                                                    <given>{{ patient.name.given }}</given>
-                                                    <family>{{ patient.name.family }}</family>
-                                                    </name>
-                                                {%- endif %}
-                                                {#- demographics -#}
-                                                <administrativeGenderCode code="{{ patient.demographics.gender.code }}" codeSystem="2.16.840.1.113883.5.1" displayName="{{ patient.demographics.gender.displayName }}" />
-                                                <birthTime value="{{ patient.demographics.birthDate }}" />
-                                                {%- if patient.demographics.deceased is defined %}
-                                                    <sdtc:deceasedInd value="{{ patient.demographics.deceased|lower }}" />
-                                                {%- endif %}
-                                                <raceCode code="{{ patient.demographics.race.code }}" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="{{ patient.demographics.race.displayName }}" />
-                                                <ethnicGroupCode code="{{ patient.demographics.ethnicity.code }}" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="{{ patient.demographics.ethnicity.displayName }}" />
-                                                {#- language -#}
-                                                {%- if patient.demographics.preferredLanguage %}
-                                                    <languageCommunication>
-                                                    <languageCode code="{{ patient.demographics.preferredLanguage.code }}" />
-                                                    <preferenceInd value="true" />
-</languageCommunication>
-{%- endif %}
-</patient>
-{#- guardian information (if exists and not null) -#}
-{%- if patient.guardian and patient.guardian.name.given %}
-<guardian>
-<guardianPerson>
-<name use="{{ patient.guardian.name.use }}">
-{%- if patient.guardian.name.prefix %}<prefix>{{ patient.guardian.name.prefix }}</prefix>{%- endif %}
-<given>{{ patient.guardian.name.given }}</given>
-<family>{{ patient.guardian.name.family }}</family>
-</name>
-</guardianPerson>
-{%- if patient.guardian.contact.address %}{{ format_address(patient.guardian.contact.address) }}{%- endif %}
-{%- if patient.guardian.contact %}{{ format_telecom(patient.guardian.contact.phone, patient.guardian.contact.email) }}{%- endif %}
-{%- if patient.guardian.relationship %}
-<guardianRole>
-<code code="{{ patient.guardian.relationship.code }}" displayName="{{ patient.guardian.relationship.displayName }}" />
-</guardianRole>
-{%- endif %}
-</guardian>
-{%- endif %}
-</patientRole>
-</recordTarget>
+{% from "components/macros.xml.j2" import format_address, format_telecom %}
+  <recordTarget xmlns="{{ nsmap[None] }}" xmlns:sdtc="{{ nsmap['sdtc'] }}" xmlns:xsi="{{ nsmap['xsi'] }}" xmlns:voc="{{ nsmap['voc'] }}">
+    <patientRole>
+      {#- patient identifiers #}
+      {% if components.patient.id.mrn %}<id root="2.16.840.1.113883.19.5" extension="{{ components.patient.id.mrn }}" />{% endif %}
+      {% if components.patient.id.ssn %}<id root="2.16.840.1.113883.4.1" extension="{{ components.patient.id.ssn }}" />{% endif %}
+      {#- patient address -#}
+      {{ format_address(addresses.person) | indent(6, True) }}
+      {#- patient contact information -#}
+      {{ format_telecom(telecom) | indent(6, True) }}
+      <patient>
+        {#- patient name -#}
+        {%- if components.patient.name %}
+        <name use="{{ components.patient.name.use }}">
+            {% if components.patient.name.prefix %}<prefix>{{ components.patient.name.prefix }}</prefix>{% endif %}
+            <given>{{ components.patient.name.given }}</given>
+            <family>{{ components.patient.name.family }}</family>
+        </name>
+        {% endif %}
+        {#- demographics -#}
+        <administrativeGenderCode code="{{ components.patient.demographics.gender.code }}" codeSystem="2.16.840.1.113883.5.1" displayName="{{ components.patient.demographics.gender.displayName }}" />
+        <birthTime value="{{ components.patient.demographics.birthDate }}" />
+        {% if components.patient.demographics.deceased is defined -%}
+        <sdtc:deceasedInd value="{{ components.patient.demographics.deceased|lower }}" />
+        {%- endif %}
+        <raceCode code="{{ components.patient.demographics.race.code }}" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="{{ components.patient.demographics.race.displayName }}" />
+        <ethnicGroupCode code="{{ components.patient.demographics.ethnicity.code }}" codeSystem="2.16.840.1.113883.6.238" codeSystemName="Race &amp; Ethnicity - CDC" displayName="{{ components.patient.demographics.ethnicity.displayName }}" />
+        {#- language -#}
+        {% if components.patient.demographics.preferredLanguage %}
+        <languageCommunication>
+            <languageCode code="{{ components.patient.demographics.preferredLanguage.code }}" />
+            <preferenceInd value="true" />
+        </languageCommunication>
+        {%- endif %}
+      </patient>
+      {#- guardian information (if exists and not null) - TODO: test this section #}
+      {%- if components.patient.guardian and components.patient.guardian.name.given %}
+      <guardian>
+        <guardianPerson>
+          <name use="{{ components.patient.guardian.name.use }}">
+          {%- if components.patient.guardian.name.prefix %}<prefix>{{ components.patient.guardian.name.prefix }}</prefix>{%- endif %}
+          <given>{{ components.patient.guardian.name.given }}</given>
+          <family>{{ components.patient.guardian.name.family }}</family>
+          </name>
+        </guardianPerson>
+          {{ format_address(addresses.person) }}
+          {{ format_telecom(telecom) }}
+          {%- if components.patient.guardian.relationship %}
+          <guardianRole>
+          <code code="{{ components.patient.guardian.relationship.code }}" displayName="{{ components.patient.guardian.relationship.displayName }}" />
+        </guardianRole>
+        {%- endif %}
+      </guardian>
+      {%- endif %}
+    </patientRole>
+  </recordTarget>

--- a/assets/templates/components/value.xml.j2
+++ b/assets/templates/components/value.xml.j2
@@ -1,0 +1,16 @@
+{% macro render_value(value) %}
+{%- if value.code %}
+<value code="{{ value.code }}" codeSystem="{{ codeSystems[value.codeSystemName|trim] }}"
+    codeSystemName="{{ value.codeSystemName }}" displayName="{{ value.displayName }}"
+    xsi:type="CD" />
+{%- elif value.unit and value.value %}
+<value unit="{{ value.unit }}" value="{{ value.value }}" xsi:type="PQ" />
+{%- elif value.low and value.high %}
+<value xsi:type="IVL_PQ">
+  {%- if value.low %}
+  <low unit="{{ value.unit }}" value="{{ value.low }}" />
+  {%- endif %}
+  <high unit="{{ value.unit }}" value="{{ value.high }}" />
+</value>
+{%- endif %}
+{%- endmacro %}

--- a/assets/templates/components/value.xml.j2
+++ b/assets/templates/components/value.xml.j2
@@ -2,6 +2,9 @@
 {%- if value.code %}
 <value code="{{ value.code }}" codeSystem="{{ codeSystems[value.codeSystemName|trim] }}"
     codeSystemName="{{ value.codeSystemName }}" displayName="{{ value.displayName }}"
+    {% if value.sdtc -%}
+    sdtc:valueSet="{{ value.sdtc.valueSet }}" sdtc:valueSetVersion="{{ value.sdtc.valueSetVersion }}"
+    {% endif -%}
     xsi:type="CD" />
 {%- elif value.unit and value.value %}
 <value unit="{{ value.unit }}" value="{{ value.value }}" xsi:type="PQ" />

--- a/assets/templates/encounters/planned.xml.j2
+++ b/assets/templates/encounters/planned.xml.j2
@@ -1,4 +1,4 @@
-{% macro render_planned_encounter(encounter, codeSystems) %}
+{% macro render_planned_encounter(encounter) %}
 <encounter classCode="ENC" moodCode="INT">
   <!-- [C-CDA R1.1] Plan of Care Activity Encounter -->
   <templateId root="2.16.840.1.113883.10.20.22.4.40" />

--- a/assets/templates/encounters/planned.xml.j2
+++ b/assets/templates/encounters/planned.xml.j2
@@ -1,0 +1,19 @@
+{% macro render_planned_encounter(encounter, codeSystems) %}
+<encounter classCode="ENC" moodCode="INT">
+  <!-- [C-CDA R1.1] Plan of Care Activity Encounter -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.40" />
+  <!-- [C-CDA R2.1] Planned Encounter (V2) -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.40" extension="2014-06-09" />
+  <id root="{{ uuid() }}" />
+  <code code="{{ encounter.code }}" codeSystem="{{ codeSystems[encounter.codeSystemName|trim] }}"
+    codeSystemName="{{ encounter.codeSystemName }}" displayName="{{ encounter.displayName }}" />
+  <statusCode code="active" />  <!-- Adding required statusCode -->
+  <effectiveTime value="20250224" />
+  <participant typeCode="LOC">
+    <participantRole classCode="SDLOC">
+      <code code="{{ encounter.participantRole.code }}" codeSystem="2.16.840.1.113883.1.11.20275"
+        codeSystemName="HealthcareServiceLocation" displayName="{{ encounter.participantRole.displayName }}" />
+    </participantRole>
+  </participant>
+</encounter>
+{%- endmacro %}

--- a/assets/templates/observations/indication.xml.j2
+++ b/assets/templates/observations/indication.xml.j2
@@ -1,4 +1,4 @@
-{% macro render_indication_obs(indication, codeSystems) %}
+{% macro render_indication_obs(indication) %}
 <observation classCode="OBS" moodCode="EVN">
   <!-- [C-CDA R1.1] Indication -->
   <templateId root="2.16.840.1.113883.10.20.22.4.19" />

--- a/assets/templates/observations/indication.xml.j2
+++ b/assets/templates/observations/indication.xml.j2
@@ -1,3 +1,4 @@
+{%- from "components/value.xml.j2" import render_value %}
 {% macro render_indication_obs(indication) %}
 <observation classCode="OBS" moodCode="EVN">
   <!-- [C-CDA R1.1] Indication -->
@@ -8,10 +9,6 @@
   <code code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
     displayName="Condition" />
   <statusCode code="completed" />
-  <value xsi:type="CD" code="{{ indication.value.code }}" codeSystem="{{ codeSystems[indication.value.codeSystemName|trim] }}"
-    codeSystemName="{{ indication.value.codeSystemName }}" displayName="{{ indication.value.displayName }}"
-    {% if indication.sdtc -%}
-    sdtc:valueSet="{{ indication.sdtc.valueSet }}" sdtc:valueSetVersion="{{ indication.sdtc.valueSetVersion }}"
-    {% endif -%}/>
+  {{- render_value(indication.value) | indent(2, True) }}
 </observation>
 {%- endmacro %}

--- a/assets/templates/observations/indication.xml.j2
+++ b/assets/templates/observations/indication.xml.j2
@@ -1,0 +1,17 @@
+{% macro render_indication_obs(indication, codeSystems) %}
+<observation classCode="OBS" moodCode="EVN">
+  <!-- [C-CDA R1.1] Indication -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.19" />
+  <!-- [C-CDA R2.1] Indication (V2) -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.19" extension="2014-06-09" />
+  <id root="{{ uuid() }}" />
+  <code code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+    displayName="Condition" />
+  <statusCode code="completed" />
+  <value xsi:type="CD" code="{{ indication.value.code }}" codeSystem="{{ codeSystems[indication.value.codeSystemName|trim] }}"
+    codeSystemName="{{ indication.value.codeSystemName }}" displayName="{{ indication.value.displayName }}"
+    {% if indication.sdtc -%}
+    sdtc:valueSet="{{ indication.sdtc.valueSet }}" sdtc:valueSetVersion="{{ indication.sdtc.valueSetVersion }}"
+    {% endif -%}/>
+</observation>
+{%- endmacro %}

--- a/assets/templates/observations/lab-result-status.xml.j2
+++ b/assets/templates/observations/lab-result-status.xml.j2
@@ -1,0 +1,14 @@
+{#- TODO: This need to be templated when needed -#}
+{% macro render_lab_result_status_obs() %}
+<observation classCode="OBS" moodCode="EVN">
+  <!-- [C-CDA ID] Laboratory Result Status (ID) -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.418"
+    extension="2020-09-01" />
+  <code code="92235-1" displayName="Laboratory Result Status"
+    codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1" />
+  <value xsi:type="CE" code="F"
+    displayName="Final results; results stored and verified. Can only be changed with a corrected result."
+    codeSystem="2.16.840.1.113883.18.51"
+    codeSystemName="HL7ResultStatus" />
+</observation>
+{%- endmacro %}

--- a/assets/templates/observations/planned.xml.j2
+++ b/assets/templates/observations/planned.xml.j2
@@ -1,0 +1,19 @@
+{% macro render_planned_obs(observation, codeSystems) %}
+<observation classCode="OBS" moodCode="RQO">
+  <!-- [C-CDA R1.1] Plan of Care Activity Observation -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.44" />
+  <!-- [C-CDA R2.0] Planned Observation (V2) -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.44" extension="2014-06-09" />
+  {#- (TODO: do we need this?) <!-- [eICR R2 STU1.1] Initial Case Report Trigger Code Lab Test Order --> -#}
+  {#- <templateId root="2.16.840.1.113883.10.20.15.2.3.4" extension="2016-12-01" /> #}
+  <id root="{{ uuid() }}" />
+  <code code="{{ observation.code }}" codeSystem="{{ codeSystems[observation.codeSystemName|trim] }}"
+    codeSystemName="{{ observation.codeSystemName }}" displayName="{{ observation.displayName }}"
+    {% if observation.sdtc -%}
+    sdtc:valueSet="{{ observation.sdtc.valueSet }}" sdtc:valueSetVersion="{{ observation.sdtc.valueSetVersion }}"
+    {% endif -%}
+    />
+  <statusCode code="active" />
+  <effectiveTime value="20250217" />
+</observation>
+{%- endmacro %}

--- a/assets/templates/observations/planned.xml.j2
+++ b/assets/templates/observations/planned.xml.j2
@@ -1,4 +1,4 @@
-{% macro render_planned_obs(observation, codeSystems) %}
+{% macro render_planned_obs(observation) %}
 <observation classCode="OBS" moodCode="RQO">
   <!-- [C-CDA R1.1] Plan of Care Activity Observation -->
   <templateId root="2.16.840.1.113883.10.20.22.4.44" />

--- a/assets/templates/observations/planned.xml.j2
+++ b/assets/templates/observations/planned.xml.j2
@@ -8,11 +8,7 @@
   {#- <templateId root="2.16.840.1.113883.10.20.15.2.3.4" extension="2016-12-01" /> #}
   <id root="{{ uuid() }}" />
   <code code="{{ observation.code }}" codeSystem="{{ codeSystems[observation.codeSystemName|trim] }}"
-    codeSystemName="{{ observation.codeSystemName }}" displayName="{{ observation.displayName }}"
-    {% if observation.sdtc -%}
-    sdtc:valueSet="{{ observation.sdtc.valueSet }}" sdtc:valueSetVersion="{{ observation.sdtc.valueSetVersion }}"
-    {% endif -%}
-    />
+    codeSystemName="{{ observation.codeSystemName }}" displayName="{{ observation.displayName }}"/>
   <statusCode code="active" />
   <effectiveTime value="20250217" />
 </observation>

--- a/assets/templates/observations/problem.xml.j2
+++ b/assets/templates/observations/problem.xml.j2
@@ -1,3 +1,4 @@
+{%- from "components/value.xml.j2" import render_value %}
 {% macro render_problem(problem) %}
 <!-- Problem Observation -->
 <observation classCode="OBS" moodCode="EVN" negationInd="false">
@@ -18,11 +19,6 @@
   <effectiveTime>
     <low value="20250216" />
   </effectiveTime>
-  <value code="{{ problem.value.code }}" codeSystem="{{ codeSystems[problem.value.codeSystemName|trim] }}"
-    codeSystemName="{{ problem.value.codeSystemName }}" displayName="{{ problem.value.displayName }}"
-    {% if problem.sdtc -%}
-    sdtc:valueSet="{{ problem.sdtc.valueSet }}" sdtc:valueSetVersion="{{ problem.sdtc.valueSetVersion }}"
-    {% endif -%}
-    xsi:type="CD" />
+  {{- render_value(problem.value) | indent(2, True) }}
 </observation>
 {%- endmacro %}

--- a/assets/templates/observations/problem.xml.j2
+++ b/assets/templates/observations/problem.xml.j2
@@ -1,0 +1,28 @@
+{% macro render_problem(problem, codeSystems) %}
+<!-- Problem Observation -->
+<observation classCode="OBS" moodCode="EVN" negationInd="false">
+  <!-- [C-CDA R1.1] Problem Observation -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.4" />
+  {# (TODO: is this line and the one below needed?) <!-- [eICR R2 STU1.1] Initial Case Report Trigger Code Problem Observation --> -#}
+  {# <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2.3.3" /> -#}
+  <id root="{{ uuid() }}" />
+  <code code="{{ problem.code }}" codeSystem="{{ codeSystems[problem.codeSystemName|trim] }}" codeSystemName="{{ problem.codeSystemName }}"
+    displayName="{{ problem.displayName }}">
+    {%- if problem.translation %}
+    <translation code="{{ problem.translation.code }}" codeSystem="{{ codeSystems[problem.translation.codeSystemName|trim] }}"
+      codeSystemName="{{ problem.translation.codeSystemName }}" displayName="{{ problem.translation.displayName }}" />
+    {%- endif %}
+  </code>
+  <statusCode code="completed" />
+  <effectiveTime>
+    <low value="20250216" />
+  </effectiveTime>
+  <value code="{{ problem.value.code }}" codeSystem="{{ codeSystems[problem.value.codeSystemName|trim] }}"
+    codeSystemName="{{ problem.value.codeSystemName }}" displayName="{{ problem.value.displayName }}"
+    {% if problem.sdtc -%}
+    sdtc:valueSet="{{ problem.sdtc.valueSet }}" sdtc:valueSetVersion="{{ problem.sdtc.valueSetVersion }}"
+    {% endif -%}
+    xsi:type="CD" />
+</observation>
+{%- endmacro %}

--- a/assets/templates/observations/problem.xml.j2
+++ b/assets/templates/observations/problem.xml.j2
@@ -1,4 +1,4 @@
-{% macro render_problem(problem, codeSystems) %}
+{% macro render_problem(problem) %}
 <!-- Problem Observation -->
 <observation classCode="OBS" moodCode="EVN" negationInd="false">
   <!-- [C-CDA R1.1] Problem Observation -->

--- a/assets/templates/observations/result.xml.j2
+++ b/assets/templates/observations/result.xml.j2
@@ -1,0 +1,47 @@
+{%- from "components/value.xml.j2" import render_value %}
+{%- from "observations/lab-result-status.xml.j2" import render_lab_result_status_obs %}
+{% macro render_result_obs(result) %}
+<observation classCode="OBS" moodCode="EVN">
+  <!-- [C-CDA R1.1] Result Observation -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+  <!-- [C-CDA R2.1] Result Observation (V3) -->
+  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.2" />
+  {#- (TODO: is this needed?) <!-- [eICR R2 STU1.1] Initial Case Report Trigger Code Result Observation --> #}
+  {#- <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2.3.2" /> #}
+  <id root="{{ uuid() }}" />
+  <code code="{{ result.code }}" codeSystem="{{ codeSystems[result.codeSystemName|trim] }}"
+    codeSystemName="{{ result.codeSystemName }}" displayName="{{ result.displayName }}"
+    {% if result.sdtc -%}
+    sdtc:valueSet="{{ result.sdtc.valueSet }}" sdtc:valueSetVersion="{{ result.sdtc.valueSetVersion }}"
+    {% endif -%}
+    xsi:type="CD" />
+  <statusCode code="completed" />
+  <effectiveTime value="20250221" />
+  {{- render_value(result.value) | indent(2, True) }}
+  {%- if result.interpretationCode %}
+  <interpretationCode code="{{ result.interpretationCode.code }}" codeSystem="2.16.840.1.113883.5.83"
+    displayName="{{ result.interpretationCode.displayName }}" />
+  {%- endif %}
+  {%- if result.referenceRange %}
+  <referenceRange>
+    <observationRange>
+      {%- if result.referenceRange.interpretationCode %}
+      <text>{{ result.referenceRange.interpretationCode.displayName }}</text>
+      {%- endif %}
+      {{- render_value(result.referenceRange.value) | indent(6, True) }}
+      {%- if result.interpretationCode %}
+      <interpretationCode code="{{ result.referenceRange.interpretationCode.code }}" codeSystem="2.16.840.1.113883.5.83"
+        displayName="{{ result.referenceRange.interpretationCode.displayName }}" />
+      {%- endif %}
+    </observationRange>
+  </referenceRange>
+  {%- endif %}
+  {%- if result.entryRelationship %}
+  <entryRelationship typeCode="COMP">
+  {%- if result.entryRelationship == "observations/lab-result-status" %}
+  {{- render_lab_result_status_obs() | indent(4, True) }}
+  {%- endif %}
+  </entryRelationship>
+  {%- endif %}
+</observation>
+{%- endmacro %}

--- a/assets/templates/observations/result.xml.j2
+++ b/assets/templates/observations/result.xml.j2
@@ -11,9 +11,6 @@
   <id root="{{ uuid() }}" />
   <code code="{{ result.code }}" codeSystem="{{ codeSystems[result.codeSystemName|trim] }}"
     codeSystemName="{{ result.codeSystemName }}" displayName="{{ result.displayName }}"
-    {% if result.sdtc -%}
-    sdtc:valueSet="{{ result.sdtc.valueSet }}" sdtc:valueSetVersion="{{ result.sdtc.valueSetVersion }}"
-    {% endif -%}
     xsi:type="CD" />
   <statusCode code="completed" />
   <effectiveTime value="20250221" />

--- a/assets/templates/observations/therapeutic-response.xml.j2
+++ b/assets/templates/observations/therapeutic-response.xml.j2
@@ -1,4 +1,4 @@
-{% macro render_therapeutic_response_obs(observation, codeSystems) %}
+{% macro render_therapeutic_response_obs(observation) %}
 <observation classCode="OBS" moodCode="EVN">
   <!-- [eICR R2] Therapeutic Medication Response Observation -->
   <templateId root="2.16.840.1.113883.10.20.15.2.3.37"

--- a/assets/templates/observations/therapeutic-response.xml.j2
+++ b/assets/templates/observations/therapeutic-response.xml.j2
@@ -1,0 +1,17 @@
+{% macro render_therapeutic_response_obs(observation, codeSystems) %}
+<observation classCode="OBS" moodCode="EVN">
+  <!-- [eICR R2] Therapeutic Medication Response Observation -->
+  <templateId root="2.16.840.1.113883.10.20.15.2.3.37"
+    extension="2019-04-01" />
+  <id root="{{ uuid() }}" />
+  <code code="67540-5" codeSystem="2.16.840.1.113883.6.1"
+    codeSystemName="LOINC" displayName="Response to medication" />
+  <statusCode code="completed" />
+  <effectiveTime>
+    <low value="20201101" />
+  </effectiveTime>
+  <value code="{{ observation.value.code }}" codeSystem="{{ codeSystems[observation.value.codeSystemName|trim] }}"
+    codeSystemName="{{ observation.value.codeSystemName }}" displayName="{{ observation.value.displayName }}"
+    xsi:type="CD" />
+</observation>
+{%- endmacro %}

--- a/assets/templates/observations/therapeutic-response.xml.j2
+++ b/assets/templates/observations/therapeutic-response.xml.j2
@@ -1,3 +1,4 @@
+{%- from "components/value.xml.j2" import render_value %}
 {% macro render_therapeutic_response_obs(observation) %}
 <observation classCode="OBS" moodCode="EVN">
   <!-- [eICR R2] Therapeutic Medication Response Observation -->
@@ -10,8 +11,6 @@
   <effectiveTime>
     <low value="20201101" />
   </effectiveTime>
-  <value code="{{ observation.value.code }}" codeSystem="{{ codeSystems[observation.value.codeSystemName|trim] }}"
-    codeSystemName="{{ observation.value.codeSystemName }}" displayName="{{ observation.value.displayName }}"
-    xsi:type="CD" />
+  {{- render_value(observation.value) | indent(2, True) }}
 </observation>
 {%- endmacro %}

--- a/assets/templates/procedures/specimen-collection.xml.j2
+++ b/assets/templates/procedures/specimen-collection.xml.j2
@@ -1,0 +1,38 @@
+{#- TODO: This need to be templated when needed -#}
+{% macro render_specimen_collection_proc() %}
+<procedure classCode="PROC" moodCode="EVN">
+  <!-- [C-CDA] Specimen Collection Procedure (ID) -->
+  <templateId root="2.16.840.1.113883.10.20.22.4.415"
+    extension="2018-09-01" />
+  <code code="17636008"
+    displayName="Specimen collection (procedure)"
+    codeSystem="2.16.840.1.113883.6.96"
+    codeSystemName="SNOMED CT" />
+  <!-- Specimen collection date/time -->
+  <effectiveTime>
+    <low value="20200309" />
+  </effectiveTime>
+  <!-- Specimen source -->
+  <targetSiteCode code="368208006"
+    displayName="Left upper arm structure (body structure)"
+    codeSystem="2.16.840.1.113883.6.96"
+    codeSystemName="SNOMED CT" />
+  <!-- [C-CDA ID]  Specimen Participant (ID) -->
+  <participant typeCode="PRD">
+    <!-- [C-CDA ID] Specimen Participant (ID) -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.310"
+      extension="2020-09-01" />
+    <participantRole classCode="SPEC">
+      <!-- Specimen id -->
+      <id root="44fd0410-6115-4b8e-8ee9-a51b3817df66" />
+      <playingEntity>
+        <!-- Specimen type -->
+        <code code="119297000"
+          displayName="Blood specimen (specimen)"
+          codeSystem="2.16.840.1.113883.6.96"
+          codeSystemName="SNOMED CT" />
+      </playingEntity>
+    </participantRole>
+  </participant>
+</procedure>
+{%- endmacro %}

--- a/assets/templates/sections/chief-complaint.xml.j2
+++ b/assets/templates/sections/chief-complaint.xml.j2
@@ -1,0 +1,10 @@
+
+        <section>
+          <templateId root="1.3.6.1.4.1.19376.1.5.3.1.1.13.2.1" />
+          <code code="10154-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+              displayName="Chief complaint Narrative - Reported" />
+          <title>Chief Complaint</title>
+          <text>
+            <paragraph>{{ sections.chief_complaint.text }}</paragraph>
+          </text>
+        </section>

--- a/assets/templates/sections/emergency-outbreak.xml.j2
+++ b/assets/templates/sections/emergency-outbreak.xml.j2
@@ -1,0 +1,42 @@
+{#- TODO: This section needs to be templated #}
+        <section>
+          <!-- [eICR R2 STU3] Emergency Outbreak Information Section -->
+          <templateId root="2.16.840.1.113883.10.20.15.2.2.4" extension="2021-01-01" />
+          <code code="83910-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Public health Note" />
+          <title>Emergency Outbreak Information Section</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Information Type</th>
+                  <th>Information Date</th>
+                  <th>Result</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Employee desk distance from mail sorter</td>
+                  <td>1 November 2020</td>
+                  <td>2 meters</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <!-- [eICR R2 STU3] Emergency Outbreak Information Observation -->
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.40"
+                extension="2021-01-01" />
+              <id root="ab1791b0-5c71-11db-b0de-0800200c9a54" />
+              <code nullFlavor="OTH">
+                <originalText>Employee desk distance from mail sorter</originalText>
+              </code>
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20201101" />
+              </effectiveTime>
+              <value xsi:type="PQ" value="2" unit="m" />
+            </observation>
+          </entry>
+        </section>

--- a/assets/templates/sections/encounters.xml.j2
+++ b/assets/templates/sections/encounters.xml.j2
@@ -1,4 +1,5 @@
 {%- from "components/macros.xml.j2" import format_address, format_telecom, format_name %}
+{%- from "components/value.xml.j2" import render_value %}
         <section>
           <!-- [C-CDA R1.1] Encounters Section (entries optional) -->
           <templateId root="2.16.840.1.113883.10.20.22.2.22" />
@@ -88,6 +89,7 @@
                                         </tr>
                                       </thead>
                                       <tbody>
+                                        {%- for i in range(encounters_diagnosis_repetitions) %}
                                         {%- for diag in sections.encounters.diagnosis %}
                                         <tr ID="{{ diag.ID }}">
                                           <td>Diagnosis</td>
@@ -98,6 +100,7 @@
                                           <td>20250216</td>
                                           <td>Feb 21, 2025</td>
                                         </tr>
+                                        {%- endfor %}
                                         {%- endfor %}
                                       </tbody>
                                     </table>
@@ -190,6 +193,7 @@
                   </assignedPerson>
                 </assignedEntity>
               </performer>
+              {%- for i in range(encounters_diagnosis_repetitions) %}
               {%- for diag in sections.encounters.diagnosis %}
               <!-- Link to Diagnosis -->
               <entryRelationship typeCode="COMP">
@@ -213,14 +217,12 @@
                       <effectiveTime>
                         <low value="20250221" />
                       </effectiveTime>
-                      <value xsi:type="CD" code="{{ diag.code }}" codeSystem="{{ codeSystems[diag.codeSystemName|trim] }}"
-                        codeSystemName="{{ diag.codeSystemName }}"
-                        displayName="{{ diag.displayName }}"
-                        sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="20250216" />
+                      {{- render_value(diag) | indent(22, True) }}
                     </observation>
                   </entryRelationship>
                 </act>
               </entryRelationship>
+              {%- endfor %}
               {%- endfor %}
             </encounter>
           </entry>

--- a/assets/templates/sections/encounters.xml.j2
+++ b/assets/templates/sections/encounters.xml.j2
@@ -1,0 +1,227 @@
+{%- from "components/macros.xml.j2" import format_address, format_telecom, format_name %}
+        <section>
+          <!-- [C-CDA R1.1] Encounters Section (entries optional) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22" />
+          <!-- [C-CDA R2.1] Encounters Section (entries optional) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22" extension="2015-08-01" />
+          <!-- [C-CDA R1.1] Encounters Section (entries required) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.1" />
+          <!-- [C-CDA R2.1] Encounters Section (entries required) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.1" extension="2015-08-01" />
+          <code code="46240-8" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="History of encounters" />
+          <title>Encounters</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Encounter</th>
+                  <th>Date(s)</th>
+                  <th>Location</th>
+                </tr>
+              </thead>
+              <tbody>
+                <!-- Initial Visit -->
+                <tr ID="encounter_20250216_ref">
+                  <td>Office outpatient visit 15 minutes</td>
+                  <td>Feb 16, 2025</td>
+                  <td>
+                    <list styleCode="none">
+                      <item>
+                        <content styleCode="Italics">{{ facility.name }}</content>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+                <!-- Follow-up Visit -->
+                <tr ID="encounter_20250217_ref">
+                  <td>Office outpatient visit - followup</td>
+                  <td>Feb 17, 2025</td>
+                  <td>
+                    <list styleCode="none">
+                      <item>
+                        <content styleCode="Italics">{{ facility.name }}</content>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+                <!-- Results Visit with Diagnoses -->
+                <tr ID="encounter_20250221_ref">
+                  <td>Office outpatient visit - results review</td>
+                  <td>Feb 21, 2025</td>
+                  <td>
+                    <list styleCode="none">
+                      <item>
+                        <content styleCode="Italics">{{ facility.name }}</content>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="20">
+                    <list styleCode="none">
+                      <item>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Encounter Diagnosis Type</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>Diagnosis</td>
+                            </tr>
+                            <tr>
+                              <td colspan="20">
+                                <list styleCode="none">
+                                  <item>
+                                    <table>
+                                      <thead>
+                                        <tr>
+                                          <th>Initial Case Report Trigger Code Problem Observation</th>
+                                          <th>Problem</th>
+                                          <th>Trigger Code</th>
+                                          <th>Trigger Code codeSystem</th>
+                                          <th>RCTC OID</th>
+                                          <th>RCTC Version</th>
+                                          <th>Date(s)</th>
+                                        </tr>
+                                      </thead>
+                                      <tbody>
+                                        {%- for diag in sections.encounters.diagnosis %}
+                                        <tr ID="{{ diag.ID }}">
+                                          <td>Diagnosis</td>
+                                          <td>{{ diag.displayName }}</td>
+                                          <td>{{ diag.code }}</td>
+                                          <td>{{ diag.codeSystemName }}</td>
+                                          <td>2.16.840.1.114222.4.11.7508</td>
+                                          <td>20250216</td>
+                                          <td>Feb 21, 2025</td>
+                                        </tr>
+                                        {%- endfor %}
+                                      </tbody>
+                                    </table>
+                                  </item>
+                                </list>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <!-- Initial Visit Entry -->
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01" />
+              <id root="d4994d30-b5a0-4526-a512-d8d7a5c7c1f3" />
+              <code code="99213" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4"
+                displayName="Office outpatient visit 15 minutes" />
+              <effectiveTime value="20250216" />
+              <participant typeCode="LOC">
+                <participantRole classCode="SDLOC">
+                  <code code="1160-1" codeSystem="2.16.840.1.113883.1.11.20275"
+                    codeSystemName="HealthcareServiceLocation"
+                    displayName="{{ facility.name }}" />
+                </participantRole>
+              </participant>
+              <performer>
+                <assignedEntity>
+                  <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+                  <assignedPerson>
+                    {{- format_name(provider.name) | indent(20, True) }}
+                  </assignedPerson>
+                </assignedEntity>
+              </performer>
+            </encounter>
+          </entry>
+          <!-- Follow-up Visit Entry -->
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01" />
+              <id root="c7a76229-eda1-4948-9332-05416f11a457" />
+              <code code="99213" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4"
+                displayName="Office outpatient visit - followup" />
+              <effectiveTime value="20250217" />
+              <participant typeCode="LOC">
+                <participantRole classCode="SDLOC">
+                  <code code="1160-1" codeSystem="2.16.840.1.113883.1.11.20275"
+                    codeSystemName="HealthcareServiceLocation"
+                    displayName="{{ facility.name }}" />
+                </participantRole>
+              </participant>
+              <performer>
+                <assignedEntity>
+                  <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+                  <assignedPerson>
+                    {{- format_name(provider.name) | indent(20, True) }}
+                  </assignedPerson>
+                </assignedEntity>
+              </performer>
+            </encounter>
+          </entry>
+          <!-- Results Visit with Diagnoses -->
+          <entry typeCode="DRIV">
+            <encounter classCode="ENC" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.49" extension="2015-08-01" />
+              <id root="6e12d84f-9e8a-45cb-b1d7-f43a72a86cc5" />
+              <code code="99212" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT-4"
+                displayName="Office outpatient visit - results review" />
+              <effectiveTime value="20250221" />
+              <participant typeCode="LOC">
+                <participantRole classCode="SDLOC">
+                  <code code="1160-1" codeSystem="2.16.840.1.113883.1.11.20275"
+                    codeSystemName="HealthcareServiceLocation"
+                    displayName="{{ facility.name }}" />
+                </participantRole>
+              </participant>
+              <performer>
+                <assignedEntity>
+                  <id extension="1234567890" root="2.16.840.1.113883.4.6" />
+                  <assignedPerson>
+                    {{- format_name(provider.name) | indent(20, True) }}
+                  </assignedPerson>
+                </assignedEntity>
+              </performer>
+              {%- for diag in sections.encounters.diagnosis %}
+              <!-- Link to Diagnosis -->
+              <entryRelationship typeCode="COMP">
+                <act classCode="ACT" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.80" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.80" extension="2015-08-01" />
+                  <code code="29308-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                    displayName="Diagnosis" />
+                  <entryRelationship typeCode="SUBJ">
+                    <observation classCode="OBS" moodCode="EVN" negationInd="false">
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" />
+                      <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+                      <templateId root="2.16.840.1.113883.10.20.15.2.3.3" extension="2016-12-01" />
+                      <id root="{{ uuid() }}" />
+                      <code code="75323-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+                        displayName="Condition">
+                        <translation code="282291009" codeSystem="2.16.840.1.113883.6.96"
+                          codeSystemName="SNOMED CT" displayName="Diagnosis" />
+                      </code>
+                      <statusCode code="completed" />
+                      <effectiveTime>
+                        <low value="20250221" />
+                      </effectiveTime>
+                      <value xsi:type="CD" code="{{ diag.code }}" codeSystem="{{ codeSystems[diag.codeSystemName|trim] }}"
+                        codeSystemName="{{ diag.codeSystemName }}"
+                        displayName="{{ diag.displayName }}"
+                        sdtc:valueSet="2.16.840.1.114222.4.11.7508" sdtc:valueSetVersion="20250216" />
+                    </observation>
+                  </entryRelationship>
+                </act>
+              </entryRelationship>
+              {%- endfor %}
+            </encounter>
+          </entry>
+        </section>

--- a/assets/templates/sections/history-of-present-illness.xml.j2
+++ b/assets/templates/sections/history-of-present-illness.xml.j2
@@ -5,8 +5,10 @@
             codeSystemName="LOINC" displayName="History of Present Illness" />
           <title>History of Present Illness</title>
           <text mediaType="text/x-hl7-text+xml">
+            {%- for i in range(history_of_present_illness_repetitions) %}
             {%- for entry in sections.history_of_present_illness.entries %}
             <paragraph>{{ entry.text }}</paragraph>
+            {%- endfor %}
             {%- endfor %}
           </text>
         </section>

--- a/assets/templates/sections/history-of-present-illness.xml.j2
+++ b/assets/templates/sections/history-of-present-illness.xml.j2
@@ -1,0 +1,12 @@
+
+        <section>
+          <templateId root="1.3.6.1.4.1.19376.1.5.3.1.3.4" />
+          <code code="10164-2" codeSystem="2.16.840.1.113883.6.1"
+            codeSystemName="LOINC" displayName="History of Present Illness" />
+          <title>History of Present Illness</title>
+          <text mediaType="text/x-hl7-text+xml">
+            {%- for entry in sections.history_of_present_illness.entries %}
+            <paragraph>{{ entry.text }}</paragraph>
+            {%- endfor %}
+          </text>
+        </section>

--- a/assets/templates/sections/immunizations.xml.j2
+++ b/assets/templates/sections/immunizations.xml.j2
@@ -1,0 +1,80 @@
+{%- from "activities/immunization-activity.xml.j2" import render_immunization_activity %}
+        <section>
+          <!-- [C-CDA R2.1] Immunizations Section (entries required)(V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.2.1" extension="2015-08-01" />
+          <code code="11369-6" displayName="Hx of Immunization"
+            codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+          <title>Immunizations</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Immunization</th>
+                  <th>Immunization Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {%- for activity in sections.immunizations.activities %}
+                <tr>
+                  <td>{{ activity.manufacturedMaterial.displayName }}</td>
+                  <td>NOV 11, 2020</td>
+                </tr>
+                {%- endfor %}
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Initial Case Report Trigger Code <br /> Immunization
+                    Medication Activity </th>
+                  <th>Immunization Date</th>
+                  <th>Trigger <br /> Code </th>
+                  <th>Trigger Code <br /> codeSystem </th>
+                  <th>RCTC OID</th>
+                  <th>RCTC <br /> Version </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>influenza virus vaccine, unspecified formulation</td>
+                  <td>NOV 11, 2020</td>
+                  <td>88</td>
+                  <td>CVX</td>
+                  <td>2.16.840.1.114222.4.11.7508</td>
+                  <td>19/05/2020</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Vaccinne Credential Patient Assertion</th>
+                  <th>Assertion Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>{{ sections.immunizations.patientAssertion.displayName }}</td>
+                  <td>NOV 11, 2020</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          {%- for activity in sections.immunizations.activities -%}
+          {{ render_immunization_activity(activity, codeSystems) | indent(10, True) }}
+          {%- endfor %}
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [eICR R2 STU3] Vaccine Credential Patient Assertion -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.55"
+                extension="2021-01-01" />
+              <id root="3adc7f4d-ff0a-4b38-9252-bd65edbe3dff" />
+              <code code="11370-4" displayName="Immunization status - Reported"
+                codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+              <statusCode code="completed" />
+              <effectiveTime value="20201107" />
+              <value xsi:type="CD" code="{{ sections.immunizations.patientAssertion.code }}" codeSystem="2.16.840.1.113883.12.136"
+                displayName="{{ sections.immunizations.patientAssertion.displayName }}" codeSystemName="Yes/No Indicator (HL7 Table 0136)" />
+            </observation>
+          </entry>
+        </section>

--- a/assets/templates/sections/immunizations.xml.j2
+++ b/assets/templates/sections/immunizations.xml.j2
@@ -14,11 +14,13 @@
                 </tr>
               </thead>
               <tbody>
+                {%- for i in range(immunization_activities_repetitions) %}
                 {%- for activity in sections.immunizations.activities %}
                 <tr>
                   <td>{{ activity.manufacturedMaterial.displayName }}</td>
                   <td>NOV 11, 2020</td>
                 </tr>
+                {%- endfor %}
                 {%- endfor %}
               </tbody>
             </table>
@@ -60,8 +62,10 @@
               </tbody>
             </table>
           </text>
+          {%- for i in range(immunization_activities_repetitions) %}
           {%- for activity in sections.immunizations.activities -%}
           {{ render_immunization_activity(activity) | indent(10, True) }}
+          {%- endfor %}
           {%- endfor %}
           <entry typeCode="DRIV">
             <observation classCode="OBS" moodCode="EVN">

--- a/assets/templates/sections/immunizations.xml.j2
+++ b/assets/templates/sections/immunizations.xml.j2
@@ -61,7 +61,7 @@
             </table>
           </text>
           {%- for activity in sections.immunizations.activities -%}
-          {{ render_immunization_activity(activity, codeSystems) | indent(10, True) }}
+          {{ render_immunization_activity(activity) | indent(10, True) }}
           {%- endfor %}
           <entry typeCode="DRIV">
             <observation classCode="OBS" moodCode="EVN">

--- a/assets/templates/sections/medications-administered.xml.j2
+++ b/assets/templates/sections/medications-administered.xml.j2
@@ -31,7 +31,7 @@
           </text>
           {%- for medication_activity in sections.medications_administered -%}
           <entry typeCode="DRIV">
-          {{ render_medication_activity(medication_activity, codeSystems) | indent(12, True) }}
+          {{ render_medication_activity(medication_activity) | indent(12, True) }}
           </entry>
           {%- endfor %}
         </section>

--- a/assets/templates/sections/medications-administered.xml.j2
+++ b/assets/templates/sections/medications-administered.xml.j2
@@ -1,0 +1,37 @@
+{%- from "activities/medication-activity.xml.j2" import render_medication_activity %}
+        <section>
+          <!-- [C-CDA R1.1] Medications Administered Section -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.38" />
+          <!-- [C-CDA R2.0] Medications Administered Section (V2) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.38" extension="2014-06-09" />
+          <code code="29549-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Medications Administered" />
+          <title>Medications Administered</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Medication</th>
+                  <th>Dose</th>
+                  <th>Duration</th>
+                  <th>Route</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for medication_activity in sections.medications_administered -%}
+                <tr ID="id_{{ loop.index }}_ref">
+                  <td>{{ medication_activity.manufacturedMaterial.displayName }}</td>
+                  <td>{{ medication_activity.doseQuantity.value }} {{ medication_activity.doseQuantity.unit }}</td>
+                  <td>NOV 7, 2020 11:59</td>
+                  <td>{{ medication_activity.route.displayName }}</td>
+                </tr>
+                {%- endfor %}
+              </tbody>
+            </table>
+          </text>
+          {%- for medication_activity in sections.medications_administered -%}
+          <entry typeCode="DRIV">
+          {{ render_medication_activity(medication_activity, codeSystems) | indent(12, True) }}
+          </entry>
+          {%- endfor %}
+        </section>

--- a/assets/templates/sections/medications-administered.xml.j2
+++ b/assets/templates/sections/medications-administered.xml.j2
@@ -18,6 +18,7 @@
                 </tr>
               </thead>
               <tbody>
+                {%- for i in range(medications_administered_repetitions) %}
                 {% for medication_activity in sections.medications_administered -%}
                 <tr ID="id_{{ loop.index }}_ref">
                   <td>{{ medication_activity.manufacturedMaterial.displayName }}</td>
@@ -26,12 +27,15 @@
                   <td>{{ medication_activity.route.displayName }}</td>
                 </tr>
                 {%- endfor %}
+                {%- endfor %}
               </tbody>
             </table>
           </text>
-          {%- for medication_activity in sections.medications_administered -%}
+          {%- for i in range(medications_administered_repetitions) %}
+          {%- for medication_activity in sections.medications_administered %}
           <entry typeCode="DRIV">
-          {{ render_medication_activity(medication_activity) | indent(12, True) }}
+          {{- render_medication_activity(medication_activity) | indent(12, True) }}
           </entry>
+          {%- endfor %}
           {%- endfor %}
         </section>

--- a/assets/templates/sections/plan-of-treatment.xml.j2
+++ b/assets/templates/sections/plan-of-treatment.xml.j2
@@ -24,22 +24,19 @@
                 </tr>
               </thead>
               <tbody>
+                {%- for i in range(plan_of_treatment_repetitions) %}
                 {%- for entry in sections.plan_of_treatment.entries %}
                 {%- if entry.type == "observations/planned" %}
                 <tr>
                   <td>{{ entry.displayName }}</td>
                   <td>{{ entry.code }}</td>
                   <td>{{ entry.codeSystemName }}</td>
-                  {%- if entry.sdtc %}
-                  <td>{{ entry.sdtc.valueSet }}</td>
-                  <td>{{ entry.sdtc.valueSetVersion }}</td>
-                  {%- else %}
                   <td/>
                   <td/>
-                  {%- endif %}
                   <td>02/17/2025</td>
                 </tr>
                 {%- endif %}
+                {%- endfor %}
                 {%- endfor %}
               </tbody>
             </table>
@@ -62,6 +59,7 @@
               {%- endfor %}
             </list>
           </text>
+          {%- for i in range(plan_of_treatment_repetitions) %}
           {%- for entry in sections.plan_of_treatment.entries %}
           <entry typeCode="DRIV">
           {%- if entry.type == "observations/planned" -%}
@@ -72,5 +70,6 @@
           {{ render_planned_encounter(entry) | indent(12, True) }}
           {%- endif %}
           </entry>
+          {%- endfor %}
           {%- endfor %}
         </section>

--- a/assets/templates/sections/plan-of-treatment.xml.j2
+++ b/assets/templates/sections/plan-of-treatment.xml.j2
@@ -1,0 +1,76 @@
+{%- from "observations/planned.xml.j2" import render_planned_obs %}
+{%- from "activities/medication-activity.xml.j2" import render_medication_activity %}
+{%- from "encounters/planned.xml.j2" import render_planned_encounter %}
+        <section>
+          <!-- [C-CDA R1.1] Plan of Care Section new -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.22.1" />
+          <templateId extension="2014-06-09"
+            root="2.16.840.1.113883.10.20.22.2.22.1" />
+          <code code="18776-5" codeSystem="2.16.840.1.113883.6.1"
+            codeSystemName="LOINC" displayName="Plan of Treatment" />
+          <title>Plan of Treatment</title>
+          <text>
+            <paragraph>*** In the table below, row entries with values under RCTC columns triggered
+              this Electronic Initial Case Report (eICR)</paragraph>
+            <table>
+              <thead>
+                <tr>
+                  <th>Lab Test Order</th>
+                  <th>Code</th>
+                  <th>CodeSystem</th>
+                  <th>RCTC OID ***</th>
+                  <th>RCTC Version ***</th>
+                  <th>Ordered Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {%- for entry in sections.plan_of_treatment.entries %}
+                {%- if entry.type == "observations/planned" %}
+                <tr>
+                  <td>{{ entry.displayName }}</td>
+                  <td>{{ entry.code }}</td>
+                  <td>{{ entry.codeSystemName }}</td>
+                  {%- if entry.sdtc %}
+                  <td>{{ entry.sdtc.valueSet }}</td>
+                  <td>{{ entry.sdtc.valueSetVersion }}</td>
+                  {%- else %}
+                  <td/>
+                  <td/>
+                  {%- endif %}
+                  <td>02/17/2025</td>
+                </tr>
+                {%- endif %}
+                {%- endfor %}
+              </tbody>
+            </table>
+
+            <paragraph>Medications</paragraph>
+            <list>
+              {%- for entry in sections.plan_of_treatment.entries %}
+              {%- if entry.type == "activities/medication-activity" %}
+              <item>{{ entry.manufacturedMaterial.originalText }}</item>
+              {%- endif %}
+              {%- endfor %}
+            </list>
+
+            <paragraph>Follow-up</paragraph>
+            <list>
+              {%- for entry in sections.plan_of_treatment.entries %}
+              {%- if entry.type == "encounters/planned" %}
+              <item>{{ entry.text }}</item>
+              {%- endif %}
+              {%- endfor %}
+            </list>
+          </text>
+          {%- for entry in sections.plan_of_treatment.entries %}
+          <entry typeCode="DRIV">
+          {%- if entry.type == "observations/planned" -%}
+          {{ render_planned_obs(entry, codeSystems) | indent(12, True) }}
+          {%- elif entry.type == "activities/medication-activity" -%}
+          {{ render_medication_activity(entry, codeSystems) | indent(12, True) }}
+          {%- elif entry.type == "encounters/planned" -%}
+          {{ render_planned_encounter(entry, codeSystems) | indent(12, True) }}
+          {%- endif %}
+          </entry>
+          {%- endfor %}
+        </section>

--- a/assets/templates/sections/plan-of-treatment.xml.j2
+++ b/assets/templates/sections/plan-of-treatment.xml.j2
@@ -65,11 +65,11 @@
           {%- for entry in sections.plan_of_treatment.entries %}
           <entry typeCode="DRIV">
           {%- if entry.type == "observations/planned" -%}
-          {{ render_planned_obs(entry, codeSystems) | indent(12, True) }}
+          {{ render_planned_obs(entry) | indent(12, True) }}
           {%- elif entry.type == "activities/medication-activity" -%}
-          {{ render_medication_activity(entry, codeSystems) | indent(12, True) }}
+          {{ render_medication_activity(entry) | indent(12, True) }}
           {%- elif entry.type == "encounters/planned" -%}
-          {{ render_planned_encounter(entry, codeSystems) | indent(12, True) }}
+          {{ render_planned_encounter(entry) | indent(12, True) }}
           {%- endif %}
           </entry>
           {%- endfor %}

--- a/assets/templates/sections/pregnancy.xml.j2
+++ b/assets/templates/sections/pregnancy.xml.j2
@@ -1,0 +1,314 @@
+{#- TODO: This section needs to be templated #}
+        <section>
+          <!--  [C-CDA PREG] Pregnancy Section -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.80" extension="2020-04-01" />
+          <code code="90767-5" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Pregnancy summary Document" />
+          <title>Pregnancy Section</title>
+          <text xmlns:voc="http://www.lantanagroup.com/voc">
+            <table>
+              <thead>
+                <tr>
+                  <th>Pregnancy Status</th>
+                  <th>Date(s) over which status holds <br /> (if no high date,
+                    status was <br /> current at time of recording) </th>
+                  <th>Determination Method</th>
+                  <th>Determination Date</th>
+                  <th>Recorded Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Pregnant</td>
+                  <td>AUG 26, 2017</td>
+                  <td>Diagnostic ultrasonography</td>
+                  <td>OCT 1, 2017</td>
+                  <td>OCT 1, 2017 10:35</td>
+                </tr>
+                <tr>
+                  <td colspan="20">
+                    <list styleCode="none">
+                      <item>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Estimated Date of Delivery</th>
+                              <th>EDD</th>
+                              <th>EDD Determination Date</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>Delivery date estimated from
+                                ovulation date</td>
+                              <td>MAY 22, 2017</td>
+                              <td>OCT 1, 2017 10:15</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Estimated Gestational Age of
+                                Pregnancy</th>
+                              <th>Days</th>
+                              <th>Determination Date</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>Gestational age Estimated from
+                                selected delivery date</td>
+                              <td>143 d</td>
+                              <td>OCT 1, 2017 10:15</td>
+                            </tr>
+                            <tr>
+                              <td colspan="20">
+                                <list styleCode="none">
+                                  <item>
+                                    <table>
+                                      <thead>
+                                        <tr>
+                                          <th>Reference to
+                                            selected
+                                            delivery
+                                            date</th>
+                                        </tr>
+                                      </thead>
+                                      <tbody>
+                                        <tr>
+                                          <td>
+                                            <linkHtml
+                                              href="#id_f3dfc576-2329-4f71-af3f-d500cab1146b_ref">Link
+                                              to
+                                              referenced
+                                              entry</linkHtml>
+                                          </td>
+                                        </tr>
+                                      </tbody>
+                                    </table>
+                                  </item>
+                                </list>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Pregnancy Outcome</th>
+                              <th>Birth Order</th>
+                              <th>Time</th>
+                              <th>Method of Delivery</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>Stillbirth (finding)</td>
+                              <td>1</td>
+                              <td>JAN 5, 2020 08:50</td>
+                              <td>Breech delivery (procedure)</td>
+                            </tr>
+                            <tr>
+                              <td>Term birth of newborn (finding)</td>
+                              <td>2</td>
+                              <td>JAN 5, 2020 10:05</td>
+                              <td>Breech delivery (procedure)</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Last menstrual period start date</th>
+                  <th>Observation Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>AUG 1, 2017</td>
+                  <td>JAN 5, 2020 10:15</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Postpartum Status</th>
+                  <th>Observation date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Mid postpartum state (finding)</td>
+                  <td>JAN 5, 2020 10:15</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <!-- Pregnancy Observation (SUPPLEMENTAL PREGNANCY) -->
+          <entry typeCode="DRIV">
+            <!-- To assert a pregnancy status of:
+           * pregnant: set value to 77386006 |Pregnant (finding)
+           * possibly pregnant: set value to 102874004 |Possible pregnancy (finding)
+           * not pregnant: set value to 60001007 |Not pregnant (finding)
+           * unknown: set nullFlavor="UNK" and value/@nullFlavor to "UNK"
+         Use the effectiveTime to indicate the date range over which the patient was pregnant/possibly
+            pregnant/not pregnant/unknown. -->
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA R1] Pregnancy Observation -->
+              <templateId root="2.16.840.1.113883.10.20.15.3.8" />
+              <!-- [C-CDA PREG] Pregnancy Observation (SUPPLEMENTAL PREGNANCY)-->
+              <templateId root="2.16.840.1.113883.10.20.22.4.293" extension="2020-04-01" />
+              <id root="bab77407-f76d-4a51-a2ed-980c8a59fe28" />
+              <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" />
+              <statusCode code="completed" />
+              <!-- Use the effectiveTime to indicate the date range over which the patient
+                   was pregnant/possibly pregnant/not pregnant/unknown. -->
+              <effectiveTime>
+                <low value="20170826" />
+              </effectiveTime>
+              <!-- eICR Data element: Pregnancy status -->
+              <value xsi:type="CD" code="77386006" displayName="Pregnant"
+                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+              <!-- eICR Data element: Pregnancy status determination method -->
+              <methodCode code="16310003"
+                displayName="Diagnostic ultrasonography (procedure)"
+                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" />
+              <performer>
+                <!-- Pregnancy Status Determination Date -->
+                <time value="20171001" />
+                <assignedEntity>
+                  <id nullFlavor="NA" />
+                </assignedEntity>
+              </performer>
+              <author>
+                <!-- eICR Data element: Pregnancy Status Recorded Date -->
+                <time value="201710011035" />
+                <assignedAuthor>
+                  <id nullFlavor="NA" />
+                </assignedAuthor>
+              </author>
+              <!-- Estimated Date of Delivery -->
+              <entryRelationship typeCode="REFR">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA PREG] Estimated Date of Delivery (SUPPLEMENTAL
+                  PREGNANCY) -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.297"
+                    extension="2020-04-01" />
+                  <id root="f3dfc576-2329-4f71-af3f-d500cab1146b" />
+                  <!-- If method of determination is known, it is included in the
+                  code chosen, if the method of determination is not known,
+                  use code 11778-8 - Delivery Date estimated (no method specified) -->
+                  <!-- eICR Data element: Estimated date of delivery (EDD) method -->
+                  <code code="11780-4" codeSystem="2.16.840.1.113883.6.1"
+                    displayName="Delivery date estimated from ovulation date"
+                    codeSystemName="LOINC" />
+                  <statusCode code="completed" />
+                  <!-- eICR Data element: EDD determination date -->
+                  <effectiveTime value="201710011015" />
+                  <!-- eICR Data element: Estimated date of delivery (EDD) -->
+                  <value xsi:type="TS" value="20170522" />
+                </observation>
+              </entryRelationship>
+              <!-- Estimated Gestational Age of Pregnancy -->
+              <entryRelationship typeCode="REFR">
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA PREG] Estimated Gestational Age of Pregnancy  -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.280"
+                    extension="2020-04-01" />
+                  <id root="9ae62b42-0e67-4ddc-8ef7-909d03732292" />
+                  <code code="11887-7" codeSystem="2.16.840.1.113883.6.1"
+                    displayName="Gestational age Estimated from selected delivery date"
+                    codeSystemName="LOINC" />
+                  <statusCode code="completed" />
+                  <!-- eICR Data element: Estimated gestational age determination
+                  date -->
+                  <effectiveTime value="201710011015" />
+                  <!-- eICR Data element: Estimated gestational age of pregnancy
+                  in days -->
+                  <value xsi:type="PQ" unit="d" value="143" />
+                  <!-- The following entryRelationship only needs to be present if
+                  the code used  is 11887-7 | Gestational age Estimated from selected delivery date. The
+                  Entry Reference template points to the relevant Estimated Date of Delivery template-->
+                  <entryRelationship typeCode="REFR">
+                    <act classCode="ACT" moodCode="EVN">
+                      <!-- [C-CDA R2.0] Entry Reference -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.122" />
+                      <!-- This ID equals the ID of the relevant Estimated
+                      Date of Delivery template -->
+                      <id root="f3dfc576-2329-4f71-af3f-d500cab1146b" />
+                      <!-- The code is nulled to "NP" Not Present" -->
+                      <code nullFlavor="NP" />
+                      <statusCode code="completed" />
+                    </act>
+                  </entryRelationship>
+                </observation>
+              </entryRelationship>
+              <!-- Pregnancy Outcome -->
+              <entryRelationship typeCode="COMP">
+                <!-- The order born in the delivery, live born or fetal death (1st,
+                2nd, 3rd, 4th, 5th, 6th, 7th, etc.). 
+                All live births and fetal losses are included. If the pregnancy plurality is 1
+                then this value will also be 1. -->
+                <sequenceNumber value="1" />
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA PREG] Pregnancy Outcome -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.284"
+                    extension="2020-04-01" />
+                  <id root="6df3e951-e6f8-441d-a298-d9d6d3f405db" />
+                  <code code="63893-2" codeSystem="2.16.840.1.113883.6.1"
+                    displayName="Outcome of Pregnancy" codeSystemName="LOINC" />
+                  <statusCode code="completed" />
+                  <!-- eICR Data element: Pregnancy outcome date -->
+                  <effectiveTime value="202001050850" />
+                  <!-- eICR Data element: Pregnancy outcome -->
+                  <value xsi:type="CD" code="237364002"
+                    codeSystem="2.16.840.1.113883.6.96"
+                    displayName="Stillbirth (finding)"
+                    codeSystemName="SNOMED CT" />
+                </observation>
+              </entryRelationship>
+            </observation>
+          </entry>
+          <!-- Last Menstrual Period -->
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [COTPS R1D2] Last Menstrual Period (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.30.3.34"
+                extension="2014-06-09" />
+              <id root="5ffea0ae-9ae5-4313-956a-30219b4a6afa" />
+              <code code="8665-2" codeSystem="2.16.840.1.113883.6.1"
+                codeSystemName="LOINC"
+                displayName="Last menstrual period start date" />
+              <statusCode code="completed" />
+              <!-- eICR Data element: Last menstrual period (LMP) -->
+              <effectiveTime value="202001051015" />
+              <value xsi:type="TS" value="20170801" />
+            </observation>
+          </entry>
+          <!-- Postpartum Status -->
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA PREG] Postpartum Status -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.285"
+                extension="2020-04-01" />
+              <id root="9701b264-0f70-47f9-bfbf-aa4f9686cd3a" />
+              <code code="249197004" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT"
+                displayName="Maternal condition during puerperium (observable entity)" />
+              <statusCode code="completed" />
+              <effectiveTime value="202001051015" />
+              <!-- eICR Data element: Postpartum status -->
+              <value xsi:type="CD" code="42814007" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT"
+                displayName="Mid postpartum state (finding)" />
+            </observation>
+          </entry>
+        </section>

--- a/assets/templates/sections/problems-section.xml.j2
+++ b/assets/templates/sections/problems-section.xml.j2
@@ -1,0 +1,94 @@
+{%- from "observations/problem.xml.j2" import render_problem %}
+        <section>
+          <!-- [C-CDA R1.1] Problem Section (entries optional)-->
+          <templateId root="2.16.840.1.113883.10.20.22.2.5" />
+          <!-- [C-CDA R2.1] Problem Section (entries optional) (V3) -->
+          <templateId extension="2015-08-01"
+            root="2.16.840.1.113883.10.20.22.2.5" />
+          <!-- [C-CDA R1.1] Problem Section (entries required) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.5.1" />
+          <!-- [C-CDA R2.1] Problem Section (entries required) (V3) -->
+          <templateId extension="2015-08-01"
+            root="2.16.840.1.113883.10.20.22.2.5.1" />
+          <code code="11450-4" codeSystem="2.16.840.1.113883.6.1"
+            codeSystemName="LOINC" displayName="Problem List" />
+          <title>Problem List</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Concern</th>
+                  <th>Concern Status</th>
+                  <th>Date(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Problem</td>
+                  <td>active</td>
+                  <td>02/16/2025</td>
+                </tr>
+                <tr>
+                  <td>
+                    <list>
+                      <item>
+                        <paragraph>*** In the table below, row entries with values under RCTC
+                          columns triggered this Electronic Initial Case Report (eICR)</paragraph>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Problem Type</th>
+                              <th>Problem</th>
+                              <th>Date(s)</th>
+                              <th>Code</th>
+                              <th>Code System</th>
+                              <th>RCTC OID ***</th>
+                              <th>RCTC Version ***</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {%- for problem in sections.problems.observations %}
+                            <tr>
+                              <td>{{ problem.displayName }}</td>
+                              <td>{{ problem.value.displayName }}</td>
+                              <td>02/16/2025</td>
+                              <td>{{ problem.value.code }}</td>
+                              <td>{{ problem.value.codeSystemName }}</td>
+                              {%- if problem.sdtc %}
+                              <td>{{ problem.sdtc.valueSet }}</td>
+                              <td>{{ problem.sdtc.valueSetVersion }}</td>
+                              {%- else %}
+                              <td />
+                              <td />
+                              {%- endif %}
+                            </tr>
+                            {%- endfor %}
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [C-CDA 1.1] Problem Concern Act -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.3" />
+              <!-- [C-CDA 2.1] Problem Concern Act (V3) -->
+              <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.3" />
+              <id root="a1c0c380-eacc-4b40-9207-85164185558d" />
+              <code code="CONC" codeSystem="2.16.840.1.113883.5.6" displayName="Concern" />
+              <statusCode code="active" />
+              <effectiveTime>
+                <low value="20250216" />
+              </effectiveTime>
+              {%- for problem in sections.problems.observations %}
+              <entryRelationship typeCode="SUBJ">
+              {{- render_problem(problem, codeSystems) | indent(16, True) }}
+              </entryRelationship>
+              {%- endfor %}
+            </act>
+          </entry>
+        </section>

--- a/assets/templates/sections/problems-section.xml.j2
+++ b/assets/templates/sections/problems-section.xml.j2
@@ -47,6 +47,7 @@
                             </tr>
                           </thead>
                           <tbody>
+                            {%- for i in range(problems_obs_repetitions) %}
                             {%- for problem in sections.problems.observations %}
                             <tr>
                               <td>{{ problem.displayName }}</td>
@@ -54,14 +55,10 @@
                               <td>02/16/2025</td>
                               <td>{{ problem.value.code }}</td>
                               <td>{{ problem.value.codeSystemName }}</td>
-                              {%- if problem.sdtc %}
-                              <td>{{ problem.sdtc.valueSet }}</td>
-                              <td>{{ problem.sdtc.valueSetVersion }}</td>
-                              {%- else %}
                               <td />
                               <td />
-                              {%- endif %}
                             </tr>
+                            {%- endfor %}
                             {%- endfor %}
                           </tbody>
                         </table>
@@ -84,10 +81,12 @@
               <effectiveTime>
                 <low value="20250216" />
               </effectiveTime>
+              {%- for i in range(problems_obs_repetitions) %}
               {%- for problem in sections.problems.observations %}
               <entryRelationship typeCode="SUBJ">
               {{- render_problem(problem) | indent(16, True) }}
               </entryRelationship>
+              {%- endfor %}
               {%- endfor %}
             </act>
           </entry>

--- a/assets/templates/sections/problems-section.xml.j2
+++ b/assets/templates/sections/problems-section.xml.j2
@@ -86,7 +86,7 @@
               </effectiveTime>
               {%- for problem in sections.problems.observations %}
               <entryRelationship typeCode="SUBJ">
-              {{- render_problem(problem, codeSystems) | indent(16, True) }}
+              {{- render_problem(problem) | indent(16, True) }}
               </entryRelationship>
               {%- endfor %}
             </act>

--- a/assets/templates/sections/problems-section.xml.j2
+++ b/assets/templates/sections/problems-section.xml.j2
@@ -69,6 +69,8 @@
               </tbody>
             </table>
           </text>
+          {%- for i in range(problems_obs_repetitions) %}
+          {%- for problem in sections.problems.observations %}
           <entry typeCode="DRIV">
             <act classCode="ACT" moodCode="EVN">
               <!-- [C-CDA 1.1] Problem Concern Act -->
@@ -81,13 +83,11 @@
               <effectiveTime>
                 <low value="20250216" />
               </effectiveTime>
-              {%- for i in range(problems_obs_repetitions) %}
-              {%- for problem in sections.problems.observations %}
               <entryRelationship typeCode="SUBJ">
               {{- render_problem(problem) | indent(16, True) }}
               </entryRelationship>
-              {%- endfor %}
-              {%- endfor %}
             </act>
           </entry>
+          {%- endfor %}
+          {%- endfor %}
         </section>

--- a/assets/templates/sections/procedures.xml.j2
+++ b/assets/templates/sections/procedures.xml.j2
@@ -1,0 +1,231 @@
+{#- TODO: This section needs to be templated #}
+        <section>
+          <!-- Procedures Section (entries required) (V2) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.7.1" extension="2014-06-09" />
+          <templateId root="2.16.840.1.113883.10.20.22.2.7.1" />
+          <code code="47519-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="History of Procedures" />
+          <title>Procedures</title>
+          <text>
+            <table border="1" width="100%">
+              <thead>
+                <tr>
+                  <th>Procedure</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Colonic polypectomy</td>
+                  <td>November 15, 2020</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <!-- Examples of the same procedure are shown in different procedure entries -->
+          <entry typeCode="DRIV">
+            <procedure classCode="PROC" moodCode="EVN">
+              <!-- [C-CDA R2.1] Procedure Activity Procedure (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                extension="2014-06-09" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.14" />
+              <id root="d68b7e32-7810-4f5b-9cc2-acd54b0fd85d" />
+              <code code="73761001" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT" displayName="Colonoscopy" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="202011151110" />
+                <high value="202011151514" />
+              </effectiveTime>
+              <specimen typeCode="SPC">
+                <specimenRole classCode="SPEC">
+                  <id root="b6d7b927-2b70-43c7-bdf3-0e7c4133062d" />
+                  <specimenPlayingEntity>
+                    <code code="309266009" codeSystem="2.16.840.1.113883.6.96"
+                      displayName="anal polyp" />
+                  </specimenPlayingEntity>
+                </specimenRole>
+              </specimen>
+              <specimen typeCode="SPC">
+                <specimenRole classCode="SPEC">
+                  <id root="a6d7b927-2b70-43c7-bdf3-0e7c4133062c" />
+                  <specimenPlayingEntity>
+                    <code code="57259009" codeSystem="2.16.840.1.113883.6.96"
+                      displayName="bile duct" />
+                  </specimenPlayingEntity>
+                </specimenRole>
+              </specimen>
+              <participant typeCode="DEV">
+                <participantRole classCode="MANU">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.37" />
+                  <id root="2.16.840.1.113883.3.3719"
+                    extension="(01)51022222233336(11)141231(17)150707(10)A213B1(21)1234"
+                    assigningAuthorityName="FDA" />
+                  <playingDevice>
+                    <code code="90412006" codeSystem="2.16.840.1.113883.6.96"
+                      displayName="Colonoscope" />
+                  </playingDevice>
+                  <scopingEntity>
+                    <id root="2.16.840.1.113883.3.3719" />
+                  </scopingEntity>
+                </participantRole>
+              </participant>
+              <participant typeCode="LOC">
+                <participantRole classCode="SDLOC">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.32" />
+                  <code code="1160-1" codeSystem="2.16.840.1.113883.6.259"
+                    codeSystemName="HealthcareServiceLocation"
+                    displayName="Community Health and Hospitals" />
+                  <addr>
+                    <streetAddressLine>1002 Healthcare Drive</streetAddressLine>
+                    <city>Ann Arbor</city>
+                    <state>MI</state>
+                    <postalCode>99999</postalCode>
+                    <country>US</country>
+                  </addr>
+                  <telecom use="WP" value="tel:+1(555)555-5000" />
+                  <playingEntity classCode="PLC">
+                    <name>Community Health and Hospitals</name>
+                  </playingEntity>
+                </participantRole>
+              </participant>
+              <entryRelationship typeCode="COMP">
+                <substanceAdministration classCode="SBADM" moodCode="EVN">
+                  <!-- ** Medication Activity (V2) ** -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.16"
+                    extension="2014-06-09" />
+                  <id root="6c844c75-aa34-411c-b7bd-5e4a9f206e29" />
+                  <statusCode code="active" />
+                  <effectiveTime xsi:type="IVL_TS">
+                    <low value="20120318" />
+                  </effectiveTime>
+                  <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true"
+                    operator="A">
+                    <period value="12" unit="h" />
+                  </effectiveTime>
+                  <routeCode code="C38288"
+                    codeSystem="2.16.840.1.113883.3.26.1.1"
+                    codeSystemName="NCI Thesaurus"
+                    displayName="ORAL" />
+                  <doseQuantity value="1" />
+                  <consumable>
+                    <manufacturedProduct classCode="MANU">
+                      <!-- ** Medication information ** -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.23"
+                        extension="2014-06-09" />
+                      <id root="2a620155-9d11-439e-92b3-5d9815ff4ee8" />
+                      <manufacturedMaterial>
+                        <code code="197380"
+                          displayName="Atenolol 25 MG Oral Tablet"
+                          codeSystem="2.16.840.1.113883.6.88"
+                          codeSystemName="RxNorm" />
+                      </manufacturedMaterial>
+                    </manufacturedProduct>
+                  </consumable>
+                  <entryRelationship typeCode="RSON">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- ** Indication ** -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.19"
+                        extension="2014-06-09" />
+                      <id root="e63166c7-6482-4a44-83a1-37ccdbde725b" />
+                      <code code="75321-0"
+                        codeSystem="2.16.840.1.113883.6.1"
+                        codeSystemName="LOINC"
+                        displayName="Clinical finding" />
+                      <statusCode code="completed" />
+                      <value xsi:type="CD"
+                        code="38341003"
+                        displayName="Hypertension"
+                        codeSystem="2.16.840.1.113883.6.96" />
+                    </observation>
+                  </entryRelationship>
+                </substanceAdministration>
+              </entryRelationship>
+            </procedure>
+          </entry>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA R2.1] Procedure Activity Observation (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.13"
+                extension="2014-06-09" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.13" />
+              <id root="6dab0739-749d-4c62-8f5e-eea77a045ce8" />
+              <code code="274025005" codeSystem="2.16.840.1.113883.6.96"
+                displayName="Colonic polypectomy" codeSystemName="SNOMED CT" />
+              <statusCode code="completed" />
+              <effectiveTime value="20201115" />
+              <value xsi:type="CD" nullFlavor="NA" />
+              <targetSiteCode code="416949008" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT" displayName="Abdomen and pelvis" />
+            </observation>
+          </entry>
+          <!-- Trigger Template: Transmission based precautions: Extracorporeal membrane
+          oxygenation (procedure) -->
+          <!-- This is an example code: at the time of publication, no RCTC value set
+          exists for procedures -->
+          <entry>
+            <procedure classCode="PROC" moodCode="EVN">
+              <!-- [C-CDA R2.1] Procedure Activity Procedure (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.14"
+                extension="2014-06-09" />
+              <!-- [eICR R2 STU3] Initial Case Report Trigger Code Procedure Activity
+              Procedure -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.44"
+                extension="2021-01-01" />
+              <id root="609a7b3b-3bd1-4e83-b621-c4afe4a90cd7" />
+              <code code="233573008" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT"
+                displayName="Extracorporeal membrane oxygenation (procedure)"
+                sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                sdtc:valueSetVersion="2020-11-13" />
+              <statusCode code="completed" />
+              <effectiveTime value="20201115" />
+            </procedure>
+          </entry>
+          <!-- Trigger Template: Transmission based precautions: Airborn precautions
+          (procedure) -->
+          <!-- This is an example code: at the time of publication, no RCTC value set
+          exists for procedures -->
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [C-CDA R2.1] Procedure Activity Act (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.12"
+                extension="2014-06-09" />
+              <!-- [eICR R2 STU3] Initial Case Report Trigger Code Procedure Activity
+              Act -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.45"
+                extension="2021-01-01" />
+              <id root="941aee94-1f69-4fa8-91c8-7eee00915728" />
+              <code code="409524006" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT"
+                displayName="Airborn precautions (procedure)"
+                sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                sdtc:valueSetVersion="2020-11-13" />
+              <statusCode code="completed" />
+              <effectiveTime value="20201115" />
+            </act>
+          </entry>
+          <!-- Trigger Template: Ventilator care and adjustment -->
+          <!-- This is an example code: at the time of publication, no RCTC value set
+          exists for procedures -->
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA R2.1] Procedure Activity Observation (V2) -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.13"
+                extension="2014-06-09" />
+              <!-- [eICR R2 STU3] Initial Case Report Trigger Code Procedure Activity
+              Observation -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.46"
+                extension="2021-01-01" />
+              <id root="e535eb92-829f-45bb-8602-a49f59bb4e2c" />
+              <code code="385857005" codeSystem="2.16.840.1.113883.6.96"
+                codeSystemName="SNOMED CT"
+                displayName="Ventilator care and adjustment (regime/therapy)"
+                sdtc:valueSet="2.16.840.1.114222.4.11.7508"
+                sdtc:valueSetVersion="2020-11-13" />
+              <statusCode code="completed" />
+              <effectiveTime value="20201115" />
+              <value xsi:type="CD" nullFlavor="NA" />
+            </observation>
+          </entry>
+        </section>

--- a/assets/templates/sections/reason-for-visit.xml.j2
+++ b/assets/templates/sections/reason-for-visit.xml.j2
@@ -1,0 +1,10 @@
+
+        <section>
+          <templateId root="2.16.840.1.113883.10.20.22.2.12" />
+          <code code="29299-5" codeSystem="2.16.840.1.113883.6.1"
+            codeSystemName="LOINC" displayName="Reason for visit" />
+          <title>Reason for visit</title>
+          <text>
+            <paragraph>{{ sections.reason_for_visit.text }}</paragraph>
+          </text>
+        </section>

--- a/assets/templates/sections/reportability-response.xml.j2
+++ b/assets/templates/sections/reportability-response.xml.j2
@@ -1,0 +1,229 @@
+{#- TODO: This section needs to be templated #}
+        <section>
+          <!-- [eICR R2 STU3] Reportability Response Information Section -->
+          <templateId root="2.16.840.1.113883.10.20.15.2.2.5" extension="2021-01-01" />
+          <code code="88085-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Reportability response report Document Public health" />
+          <title>Reportability Response Information Section</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>TODO</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>TODO</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <!-- Reportability Response Coded Information Organizer -->
+          <entry typeCode="DRIV">
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <!-- [RR R1S1] Reportability Response Coded Information Organizer -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.34"
+                extension="2017-04-01" />
+              <code code="RR11" displayName="Reportability Response Coded Information"
+                codeSystem="2.16.840.1.114222.4.5.232"
+                codeSystemName="PHIN Questions" />
+              <statusCode code="completed" />
+              <!-- Relevant Reportable Condition Observation: Zika -->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [RR R1S1] Relevant Reportable Condition Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.15.2.3.12"
+                    extension="2017-04-01" />
+                  <id root="a054d401-7b23-4b15-bc28-c889c156ba6a" />
+                  <code code="64572001" codeSystem="2.16.840.1.113883.6.96"
+                    codeSystemName="SNOMED" displayName="Condition">
+                    <translation code="75323-6"
+                      codeSystem="2.16.840.1.113883.6.1"
+                      codeSystemName="LOINC" displayName="Condition" />
+                  </code>
+                  <!-- Condition code (SNOMED CT) -->
+                  <value xsi:type="CD" code="3928002"
+                    codeSystem="2.16.840.1.113883.6.96"
+                    codeSystemName="SNOMED CT"
+                    displayName="Zika virus disease (disorder)" />
+                  <!-- Reportability Information Organizer: Both Home and Provider -->
+                  <entryRelationship typeCode="COMP">
+                    <organizer classCode="CLUSTER" moodCode="EVN">
+                      <!-- [RR R1S1] Reportability Information Organizer: Both
+                      Home and Provider -->
+                      <templateId root="2.16.840.1.113883.10.20.15.2.3.13"
+                        extension="2017-04-01" />
+                      <id root="fcf92143-4289-450e-9550-8d574facf626" />
+                      <!-- Relevant location (home, provider, or both) -->
+                      <code code="RRVS7"
+                        codeSystem="2.16.840.1.114222.4.5.274"
+                        codeSystemName="PHIN VS (CDC Local Coding System)"
+                        displayName="Both patient home address and provider facility address"></code>
+                      <statusCode code="completed" />
+                      <!-- Responsible Agency: State Department of Health -->
+                      <!-- In this case the responsible agency is the same as
+                      the rules authoring agency -->
+                      <participant typeCode="LOC">
+                        <!-- [RR R1S1] Responsible Agency -->
+                        <templateId root="2.16.840.1.113883.10.20.15.2.4.2"
+                          extension="2017-04-01" />
+                        <!-- If the responsible and authoring agencies are
+                        the same 
+               then they will have the same identifying and contact details -->
+                        <participantRole>
+                          <id extension="12341234"
+                            root="2.16.840.1.113883.4.6" />
+                          <code code="RR8"
+                            displayName="Responsible Agency"
+                            codeSystem="2.16.840.1.114222.4.5.232"
+                            codeSystemName="PHIN Questions"></code>
+                          <addr use="WP">
+                            <streetAddressLine>7777 Health Authority
+                              Drive</streetAddressLine>
+                            <city />
+                            <state>State</state>
+                            <postalCode>99999</postalCode>
+                          </addr>
+                          <telecom use="WP" value="tel:+1-555-555-3555" />
+                          <telecom use="WP" value="fax:+1-955-555-3555" />
+                          <telecom use="WP"
+                            value="mailto:mail@healthauthoritywest.gov" />
+                          <telecom use="WP"
+                            value="https://www.healthauthoritywest.gov" />
+                          <playingEntity>
+                            <name>State Department of Health</name>
+                            <desc>Responsible Agency Description</desc>
+                          </playingEntity>
+                        </participantRole>
+                      </participant>
+                      <!-- Rules Authoring Agency: State Department of Health -->
+                      <!-- In this case the rules authoring agency is the same
+                      as the responsible agency -->
+                      <participant typeCode="LOC">
+                        <!-- [RR R1S1] Rules Authoring Agency -->
+                        <templateId root="2.16.840.1.113883.10.20.15.2.4.3"
+                          extension="2017-04-01" />
+                        <!-- If the responsible and authoring agencies are
+                        the same 
+               then they will have the same identifying and contact details -->
+                        <participantRole>
+                          <id extension="12341234"
+                            root="2.16.840.1.113883.4.6" />
+                          <code code="RR12"
+                            displayName="Rules Authoring Agency"
+                            codeSystem="2.16.840.1.114222.4.5.232"
+                            codeSystemName="PHIN Questions" />
+                          <addr use="WP">
+                            <streetAddressLine>7777 Health Authority
+                              Drive</streetAddressLine>
+                            <city>City</city>
+                            <state>State</state>
+                            <postalCode>99999</postalCode>
+                          </addr>
+                          <telecom use="WP" value="tel:+1-555-555-3555" />
+                          <telecom use="WP" value="fax:+1-955-555-3555" />
+                          <telecom use="WP"
+                            value="mailto:mail@healthauthoritywest.gov" />
+                          <telecom use="WP"
+                            value="https://www.healthauthoritywest.gov" />
+                          <playingEntity>
+                            <name>State Department of Health</name>
+                            <desc>Rules Authoring Agency Description</desc>
+                          </playingEntity>
+                        </participantRole>
+                      </participant>
+                      <!-- Routing Entity: State Department of Health -->
+                      <!-- The routing entity is optional -->
+                      <participant typeCode="LOC">
+                        <!-- [RR R1S1] Routing Agency -->
+                        <templateId root="2.16.840.1.113883.10.20.15.2.4.1"
+                          extension="2017-04-01" />
+                        <participantRole>
+                          <id extension="43214321"
+                            root="2.16.840.1.113883.4.6" />
+                          <code code="RR7" displayName="Routing Entity"
+                            codeSystem="2.16.840.1.114222.4.5.232"
+                            codeSystemName="PHIN Questions" />
+                          <addr use="WP">
+                            <streetAddressLine>7777 Health Authority
+                              Drive</streetAddressLine>
+                            <city>City</city>
+                            <state>State</state>
+                            <postalCode>99999</postalCode>
+                          </addr>
+                          <telecom use="WP" value="tel:+1-555-555-3555" />
+                          <telecom use="WP" value="fax:+1-955-555-3555" />
+                          <telecom use="WP"
+                            value="mailto:mail@healthauthoritywest.gov" />
+                          <telecom use="WP"
+                            value="https://www.healthauthoritywest.gov" />
+                          <playingEntity>
+                            <name>State Department of Health Routing
+                              Agency</name>
+                            <desc>Routing Agency Description</desc>
+                          </playingEntity>
+                        </participantRole>
+                      </participant>
+                      <!-- Determination of Reportability: Zika/State
+                      Department of Health -->
+                      <component typeCode="COMP">
+                        <observation classCode="OBS" moodCode="EVN">
+                          <!-- [RR R1S1] Determination of Reportability -->
+                          <templateId
+                            root="2.16.840.1.113883.10.20.15.2.3.19"
+                            extension="2017-04-01" />
+                          <id root="e39d6ae2-8c6e-4638-9b33-412996586f41" />
+                          <code code="RR1"
+                            codeSystem="2.16.840.1.114222.4.5.232"
+                            codeSystemName="PHIN Questions"
+                            displayName="Determination of reportability" />
+                          <value xsi:type="CD" code="RRVS1"
+                            displayName="Reportable"
+                            codeSystem="2.16.840.1.114222.4.5.274"
+                            codeSystemName="PHIN VS (CDC Local Coding System)" />
+                          <!-- Determination of Reportability Reason -->
+                          <entryRelationship typeCode="RSON">
+                            <observation classCode="OBS" moodCode="EVN">
+                              <!-- [RR R1S1] Determination of
+                              Reportability Reason -->
+                              <templateId
+                                root="2.16.840.1.113883.10.20.15.2.3.26"
+                                extension="2017-04-01" />
+                              <id
+                                root="8709a342-56ad-425a-b7b1-76a16c2dd2d5" />
+                              <code code="RR2"
+                                codeSystem="2.16.840.1.114222.4.5.232"
+                                codeSystemName="PHIN Questions"
+                                displayName="Determination of reportability reason" />
+                              <value xsi:type="ST">Reason for
+                                determination of reportability</value>
+                            </observation>
+                          </entryRelationship>
+                          <!-- Determination of Reportability Rule -->
+                          <entryRelationship typeCode="RSON">
+                            <observation classCode="OBS" moodCode="EVN">
+                              <!-- [RR R1S1] Determination of
+                              Reportability Rule -->
+                              <templateId
+                                root="2.16.840.1.113883.10.20.15.2.3.27"
+                                extension="2017-04-01" />
+                              <id
+                                root="f2dfdffb-bccb-4ee4-9b6c-0ae82b15ada6" />
+                              <code code="RR3"
+                                codeSystem="2.16.840.1.114222.4.5.232"
+                                codeSystemName="PHIN Questions"
+                                displayName="Determination of reportability rule" />
+                              <value xsi:type="ST">Rule used in
+                                reportability determination</value>
+                            </observation>
+                          </entryRelationship>
+                        </observation>
+                      </component>
+                    </organizer>
+                  </entryRelationship>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>

--- a/assets/templates/sections/results.xml.j2
+++ b/assets/templates/sections/results.xml.j2
@@ -1,0 +1,118 @@
+
+        <section>
+          <!-- [C-CDA R1.1] Results Section (entries optional) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.3" />
+          <!-- [C-CDA R2.1] Results Section (entries optional) (V3) -->
+          <templateId extension="2015-08-01"
+            root="2.16.840.1.113883.10.20.22.2.3" />
+          <!-- [C-CDA R1.1] Results Section (entries required) -->
+          <templateId
+            root="2.16.840.1.113883.10.20.22.2.3.1" />
+          <!-- [C-CDA R2.1] Results Section (entries required) (V3) -->
+          <templateId extension="2015-08-01"
+            root="2.16.840.1.113883.10.20.22.2.3.1" />
+          <code code="30954-2"
+            codeSystem="2.16.840.1.113883.6.1"
+            codeSystemName="LOINC"
+            displayName="Relevant diagnostic tests and/or laboratory data" />
+          <title>Results</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Results Panel</th>
+                  <th>Date(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for result in sections.results -%}
+                <tr>
+                  <td>{{ result.displayName }}</td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>
+                    <list>
+                      <item>
+                        <paragraph>*** In the table below, row entries with values under RCTC
+                          columns triggered this
+                          Electronic Initial Case Report (eICR)</paragraph>
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Test</th>
+                              <th>Lab Test RCTC OID ***</th>
+                              <th>Lab Test RCTC Version ***</th>
+                              <th>Outcome</th>
+                              <th>Date(s)</th>
+                              <th>Lab Result RCTC OID ***</th>
+                              <th>Lab Result RCTC Version ***</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr>
+                              <td>{{ result.displayName }}</td>
+                              {%- if result.sdtc %}
+                              <td>{{ result.sdtc.valueSet }}</td>
+                              <td>{{ result.sdtc.valueSetVersion }}</td>
+                              {%- else %}
+                              <td />
+                              <td />
+                              {%- endif %}
+                              <td>{{ result.value.displayName }}</td>
+                              <td>02/21/2025</td>
+                              <td />
+                              <td />
+                            </tr>
+                          </tbody>
+                        </table>
+                      </item>
+                    </list>
+                  </td>
+                </tr>
+                {%- endfor %}
+              </tbody>
+            </table>
+          </text>
+          {% for result in sections.results -%}
+          <!-- Test Result Entry -->
+          <entry typeCode="DRIV">
+            <organizer classCode="BATTERY" moodCode="EVN">
+              <!-- [C-CDA R1.1] Result Organizer -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.1" />
+              <!-- [C-CDA R2.1] Result Organizer (V3) -->
+              <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.1" />
+              <id root="{{ uuid() }}" />
+              <code code="{{ result.code }}" codeSystem="{{ codeSystems[result.codeSystemName|trim] }}"
+                codeSystemName="{{ result.codeSystemName }}" displayName="{{ result.displayName }}" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20250221" />
+                <high value="20250221" />
+              </effectiveTime>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- [C-CDA R1.1] Result Observation -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.2" />
+                  <!-- [C-CDA R2.1] Result Observation (V3) -->
+                  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.2" />
+                  <!-- [eICR R2 STU1.1] Initial Case Report Trigger Code Result Observation -->
+                  <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2.3.2" />
+                  <id root="{{ uuid() }}" />
+                  <code code="{{ result.code }}" codeSystem="{{ codeSystems[result.codeSystemName|trim] }}"
+                    codeSystemName="{{ result.codeSystemName }}" displayName="{{ result.displayName }}"
+                    {% if result.sdtc -%}
+                    sdtc:valueSet="{{ result.sdtc.valueSet }}" sdtc:valueSetVersion="{{ result.sdtc.valueSetVersion }}"
+                    {% endif -%}
+                    xsi:type="CD" />
+                  <statusCode code="completed" />
+                  <effectiveTime value="20250221" />
+                  <value code="{{ result.value.code }}" codeSystem="{{ codeSystems[result.value.codeSystemName|trim] }}"
+                    codeSystemName="{{ result.value.codeSystemName }}" displayName="{{ result.value.displayName }}"
+                    xsi:type="CD" />
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+          {%- endfor %}
+        </section>

--- a/assets/templates/sections/results.xml.j2
+++ b/assets/templates/sections/results.xml.j2
@@ -59,13 +59,8 @@
                             {%- if component.type == "observations/result" %}
                             <tr>
                               <td>{{ component.displayName }}</td>
-                              {%- if component.sdtc %}
-                              <td>{{ component.sdtc.valueSet }}</td>
-                              <td>{{ component.sdtc.valueSetVersion }}</td>
-                              {%- else %}
                               <td />
                               <td />
-                              {%- endif %}
                               <td>{{ component.value.displayName }}</td>
                               {%- if component.interpretationCode %}
                               <td>{{ component.interpretationCode.displayName }}</td>

--- a/assets/templates/sections/results.xml.j2
+++ b/assets/templates/sections/results.xml.j2
@@ -1,4 +1,6 @@
-
+{%- from "observations/result.xml.j2" import render_result_obs %}
+{%- from "observations/lab-result-status.xml.j2" import render_lab_result_status_obs %}
+{%- from "procedures/specimen-collection.xml.j2" import render_specimen_collection_proc %}
         <section>
           <!-- [C-CDA R1.1] Results Section (entries optional) -->
           <templateId root="2.16.840.1.113883.10.20.22.2.3" />
@@ -25,7 +27,8 @@
                 </tr>
               </thead>
               <tbody>
-                {% for result in sections.results -%}
+                {%- for i in range(lab_results_repetitions) %}
+                {%- for result in sections.results %}
                 <tr>
                   <td>{{ result.displayName }}</td>
                   <td />
@@ -44,26 +47,44 @@
                               <th>Lab Test RCTC OID ***</th>
                               <th>Lab Test RCTC Version ***</th>
                               <th>Outcome</th>
+                              <th>Interpretation</th>
                               <th>Date(s)</th>
-                              <th>Lab Result RCTC OID ***</th>
-                              <th>Lab Result RCTC Version ***</th>
+                              <th>Reference Range</th>
+                              <th>Reference Range Interpretation</th>
+                              <th>Reference Range Description</th>
                             </tr>
                           </thead>
                           <tbody>
+                            {%- for component in result.components %}
+                            {%- if component.type == "observations/result" %}
                             <tr>
-                              <td>{{ result.displayName }}</td>
-                              {%- if result.sdtc %}
-                              <td>{{ result.sdtc.valueSet }}</td>
-                              <td>{{ result.sdtc.valueSetVersion }}</td>
+                              <td>{{ component.displayName }}</td>
+                              {%- if component.sdtc %}
+                              <td>{{ component.sdtc.valueSet }}</td>
+                              <td>{{ component.sdtc.valueSetVersion }}</td>
                               {%- else %}
                               <td />
                               <td />
                               {%- endif %}
-                              <td>{{ result.value.displayName }}</td>
+                              <td>{{ component.value.displayName }}</td>
+                              {%- if component.interpretationCode %}
+                              <td>{{ component.interpretationCode.displayName }}</td>
+                              {%- else %}
+                              <td/>
+                              {%- endif %}
                               <td>02/21/2025</td>
+                              {%- if component.referenceRange %}
+                              <td>{{ component.referenceRange.value.displayName }}</td>
+                              <td>{{ component.referenceRange.interpretationCode.displayName }}</td>
+                              <td>{{ component.referenceRange.interpretationCode.displayName }}</td>
+                              {%- else %}
                               <td />
                               <td />
+                              <td />
+                              {%- endif %}
                             </tr>
+                            {%- endif %}
+                            {%- endfor %}
                           </tbody>
                         </table>
                       </item>
@@ -71,10 +92,12 @@
                   </td>
                 </tr>
                 {%- endfor %}
+                {%- endfor %}
               </tbody>
             </table>
           </text>
-          {% for result in sections.results -%}
+          {%- for i in range(lab_results_repetitions) %}
+          {%- for result in sections.results %}
           <!-- Test Result Entry -->
           <entry typeCode="DRIV">
             <organizer classCode="BATTERY" moodCode="EVN">
@@ -90,29 +113,19 @@
                 <low value="20250221" />
                 <high value="20250221" />
               </effectiveTime>
-              <component>
-                <observation classCode="OBS" moodCode="EVN">
-                  <!-- [C-CDA R1.1] Result Observation -->
-                  <templateId root="2.16.840.1.113883.10.20.22.4.2" />
-                  <!-- [C-CDA R2.1] Result Observation (V3) -->
-                  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.2" />
-                  <!-- [eICR R2 STU1.1] Initial Case Report Trigger Code Result Observation -->
-                  <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2.3.2" />
-                  <id root="{{ uuid() }}" />
-                  <code code="{{ result.code }}" codeSystem="{{ codeSystems[result.codeSystemName|trim] }}"
-                    codeSystemName="{{ result.codeSystemName }}" displayName="{{ result.displayName }}"
-                    {% if result.sdtc -%}
-                    sdtc:valueSet="{{ result.sdtc.valueSet }}" sdtc:valueSetVersion="{{ result.sdtc.valueSetVersion }}"
-                    {% endif -%}
-                    xsi:type="CD" />
-                  <statusCode code="completed" />
-                  <effectiveTime value="20250221" />
-                  <value code="{{ result.value.code }}" codeSystem="{{ codeSystems[result.value.codeSystemName|trim] }}"
-                    codeSystemName="{{ result.value.codeSystemName }}" displayName="{{ result.value.displayName }}"
-                    xsi:type="CD" />
-                </observation>
-              </component>
+                {%- for component in result.components %}
+                <component>
+                {%- if component.type == "observations/result" %}
+                {{- render_result_obs(component) | indent(18, True) }}
+                {%- elif component.type == "observations/lab-result-status" %}
+                {{- render_lab_result_status_obs() | indent(18, True) }}
+                {%- elif component.type == "procedures/specimen-collection" %}
+                {{- render_specimen_collection_proc() | indent(18, True) }}
+                {%- endif %}
+                </component>
+                {%- endfor %}
             </organizer>
           </entry>
+          {%- endfor %}
           {%- endfor %}
         </section>

--- a/assets/templates/sections/social-history.xml.j2
+++ b/assets/templates/sections/social-history.xml.j2
@@ -1,0 +1,136 @@
+
+        <section>
+          <!-- [C-CDA 1.1] Social History Section-->
+          <templateId root="2.16.840.1.113883.10.20.22.2.17" />
+          <!-- [C-CDA 2.1] Social History Section (V3) -->
+          <templateId extension="2015-08-01"
+            root="2.16.840.1.113883.10.20.22.2.17" />
+          <code code="29762-2" codeSystem="2.16.840.1.113883.6.1"
+            codeSystemName="LOINC" displayName="Social History" />
+          <title>Social History</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Birth Sex</th>
+                  <th>Value</th>
+                  <th>Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Sex Assigned At Birth</td>
+                  <td>{{ sections.social_history.birth_sex.displayName }}</td>
+                  <td>{{ sections.social_history.birth_sex.dateStr }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Social History Observation Type</th>
+                  <th>Value</th>
+                  <th>Dates(s)</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Occupation / Employment details</td>
+                  <td>{{ sections.social_history.occupation.details }}</td>
+                  <td />
+                </tr>
+                <tr>
+                  <td>Pregnancy Status</td>
+                  <td>{{ sections.social_history.pregnancy_status.displayName }}</td>
+                  <td />
+                </tr>
+              </tbody>
+            </table>
+            <table>
+              <thead>
+                <tr>
+                  <th>Travel History: Date(s)</th>
+                  <th>Notes</th>
+                  <th>Location</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>{{ sections.social_history.travel_history.datesStr }}</td>
+                  <td>{{ sections.social_history.travel_history.text }}</td>
+                  <td />
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- [C-CDA R2.1 Companion Guide] Birth Sex Observation -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.200" />
+              <templateId extension="2016-06-01"
+                root="2.16.840.1.113883.10.20.22.4.200" />
+              <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"
+                codeSystemName="LOINC"
+                displayName="Sex Assigned At Birth" />
+              <statusCode code="completed" />
+              <!-- effectiveTime if present should match birthTime -->
+              <effectiveTime value="{{ sections.social_history.birth_sex.dateValue }}" />
+              <value code="{{ sections.social_history.birth_sex.code }}" codeSystem="2.16.840.1.113883.5.1"
+                codeSystemName="AdministrativeGender"
+                displayName="{{ sections.social_history.birth_sex.displayName }}" xsi:type="CD" />
+            </observation>
+          </entry>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.38" />
+              <templateId extension="2015-08-01"
+                root="2.16.840.1.113883.10.20.22.4.38" />
+              <id root="db524287-4744-4ff8-a496-d775755a1ef2" />
+              <code code="11295-3" codeSystem="2.16.840.1.113883.6.1"
+                displayName="Occupation" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20250216" />
+              </effectiveTime>
+              <value code="{{ sections.social_history.occupation.code }}"
+                codeSystem="2.16.840.1.113883.6.243"
+                displayName="{{ sections.social_history.occupation.displayName }}" />
+            </observation>
+          </entry>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.269" />
+              <id root="b0784a8c-4c9f-4e67-8983-3d5c6d945807" />
+              <code code="82810-3"
+                codeSystem="2.16.840.1.113883.6.1"
+                codeSystemName="LOINC"
+                displayName="Pregnancy status" />
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="20250216" />
+              </effectiveTime>
+              <value xsi:type="CD"
+                code="{{ sections.social_history.pregnancy_status.code }}"
+                codeSystem="{{ codeSystems[sections.social_history.pregnancy_status.codeSystemName|trim] }}"
+                codeSystemName="{{ sections.social_history.pregnancy_status.codeSystemName }}"
+                displayName="{{ sections.social_history.pregnancy_status.displayName }}" />
+            </observation>
+          </entry>
+          {#- TODO: Use a for loop and array in the data to fill many travel histories (in text above too) - use uuid() for the id -#}
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <!-- [eICR R2 STU1.1] Travel History -->
+              <templateId root="2.16.840.1.113883.10.20.15.2.3.1" />
+              <templateId extension="2016-12-01" root="2.16.840.1.113883.10.20.15.2.3.1" />
+              <id root="79565142-eae0-4213-a3b3-b73cdf474682" />
+              <code code="420008001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT"
+                displayName="Travel" />
+              <text>{{ sections.social_history.travel_history.text }}</text>
+              <statusCode code="completed" />
+              <effectiveTime>
+                <low value="{{ sections.social_history.travel_history.start }}" />
+                <high value="{{ sections.social_history.travel_history.end }}" />
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>

--- a/assets/templates/sections/vital-signs.xml.j2
+++ b/assets/templates/sections/vital-signs.xml.j2
@@ -1,0 +1,217 @@
+{#- Vital sign observations could be extracted into their own template if needed #}
+        <section>
+          <!-- [C-CDA R2.1] Vital Signs Section (entries required) (V3) -->
+          <templateId root="2.16.840.1.113883.10.20.22.2.4.1" extension="2015-08-01" />
+          <code code="8716-3" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"
+            displayName="Vital Signs" />
+          <title>Vital Signs (Last Filed)</title>
+          <text>
+            <table>
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Blood Pressure</th>
+                  <th>Pulse</th>
+                  <th>Temperature</th>
+                  <th>Respiratory Rate</th>
+                  <th>Height</th>
+                  <th>Weight</th>
+                  <th>BMI</th>
+                  <th>SpO2</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>05/20/2014 7:36pm</td>
+                  <!-- You can consolidate Systolic and Diastolic in human view if
+                  desired but should retain separate references-->
+                  <td>
+                    <content ID="SystolicBP_2">{{ sections.vital_signs.systolic }}</content>/ <content
+                      ID="DiastolicBP_2">{{ sections.vital_signs.diastolic }}</content>mm[Hg] </td>
+                  <td ID="Pulse_2">{{ sections.vital_signs.pulse }} /min</td>
+                  <td ID="Temp_2">{{ sections.vital_signs.temp }} F</td>
+                  <td ID="RespRate_2">{{ sections.vital_signs.respiratoryRate }} /min</td>
+                  <td ID="Height_2">{{ sections.vital_signs.heightStr }}</td>
+                  <td ID="Weight_2">{{ sections.vital_signs.weight }} lbs</td>
+                  <td ID="BMI_2">{{ sections.vital_signs.bmi }} kg/m2</td>
+                  <td ID="SPO2_2">{{ sections.vital_signs.spo }}%</td>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <entry typeCode="DRIV">
+            <!-- When a set of vital signs are recorded together, include them in single
+            clustered organizer-->
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.26" />
+              <templateId root="2.16.840.1.113883.10.20.22.4.26"
+                extension="2015-08-01" />
+              <id root="e421f5c8-29c2-4798-9cb5-7988c236e49d" />
+              <code code="46680005" displayName="Vital Signs"
+                codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT">
+                <translation code="74728-7"
+                  displayName="Vital signs, weight, height, head circumference, oximetry, BMI, and BSA panel "
+                  codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" />
+              </code>
+              <statusCode code="completed" />
+              <effectiveTime value="20140520193605-0500" />
+              <!-- Each vital sign should be its own component. Note that systolic and
+              diastolic BP must be separate components-->
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="2721acc5-0d05-4402-9e62-79943ea3901c" />
+                  <code code="8480-6" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="SYSTOLIC BLOOD PRESSURE" />
+                  <text>
+                    <!-- This reference identifies content in human readable
+                    formatted text-->
+                    <reference value="#SystolicBP_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Example of Value with UCUM unit. Note that mixed metric and
+                  imperial units used in this example-->
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.systolic }}" unit="mm[Hg]" />
+                  <!-- Additional information of interpretation and/or reference
+                  range may be included but are optional-->
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="88a01c83-a096-4705-a992-b5f59eca8c8c" />
+                  <code code="8462-4" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC"
+                    displayName="DIASTOLIC BLOOD PRESSURE" />
+                  <text>
+                    <reference value="#DiastolicBP_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.diastolic }}" unit="mm[Hg]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="83bbffe1-54e5-4984-a32d-ad8f8d6896d8" />
+                  <code code="8867-4" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="HEART RATE" />
+                  <text>
+                    <reference value="#Pulse_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.pulse }}" unit="/min" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="85f5784f-2958-4321-b7b6-3030d1577dc0" />
+                  <code code="8310-5" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="BODY TEMPERATURE" />
+                  <text>
+                    <reference value="#Temp_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify degrees
+                  Farenheit-->
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.temp }}" unit="[degF]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="b618fa98-6596-4e19-a9e7-6bdb48012fc8" />
+                  <code code="9279-1" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="RESPIRATORY RATE" />
+                  <text>
+                    <reference value="#RespRate_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.respiratoryRate }}" unit="/min" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="1b1274a9-b45f-449a-8493-08eaeaeba7d6" />
+                  <code code="8302-2" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="HEIGHT" />
+                  <text>
+                    <reference value="#Height_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify inches-->
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.height }}" unit="[in_us]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="1c1f89f1-8e93-4a46-b37f-9434f99727b8" />
+                  <code code="3141-9" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="WEIGHT" />
+                  <text>
+                    <reference value="#Weight_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <!-- Note the UCUM conformant way to specify pounds-->
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.weight }}" unit="[lb_av]" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="fd4ccd0b-c045-4587-8976-a17e2e064a1e" />
+                  <code code="39156-5" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="BODY MASS INDEX" />
+                  <text>
+                    <reference value="#BMI_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.bmi }}" unit="kg/m2" />
+                </observation>
+              </component>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27" />
+                  <templateId root="2.16.840.1.113883.10.20.22.4.27"
+                    extension="2014-06-09" />
+                  <id root="0ef4afda-1638-4ad2-9978-7321bbceb0cb" />
+                  <code code="2710-2" codeSystem="2.16.840.1.113883.6.1"
+                    codeSystemName="LOINC" displayName="OXYGEN SATURATION" />
+                  <text>
+                    <reference value="#SPO2_2" />
+                  </text>
+                  <statusCode code="completed" />
+                  <effectiveTime value="20140520193605-0500" />
+                  <value xsi:type="PQ" value="{{ sections.vital_signs.spo }}" unit="%" />
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+        </section>

--- a/scripts/generate_ecr.py
+++ b/scripts/generate_ecr.py
@@ -2,6 +2,15 @@ from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
 import json
 from utils import generate_uuid, generate_timestamp
+import argparse
+
+parser = argparse.ArgumentParser(description='Generate ECR XML file from a given mapping json file.')
+parser.add_argument('-m', '--mapping', type=str, help='File name of mapping json file, will default to mon-mothma-covid.json')
+args = parser.parse_args()
+mapping_file = "mon-mothma-covid.json"
+
+if args.mapping:
+  mapping_file = args.mapping
 
 # Setup the Jinja environment to load templates
 env = Environment(
@@ -18,9 +27,17 @@ template = env.get_template('components/base.xml.j2')
 
 # Define the data you want to inject
 base_path = Path(__file__).resolve().parent.parent
-json_path = base_path / "assets" / "mappings" / "mon-mothma-covid.json"
+json_path = base_path / "assets" / "mappings" / mapping_file
 with open(json_path) as f:
     data = json.load(f)
+
+# Set globals from data
+if 'config' in data :
+  if 'lab_results_repetitions' in data['config']:
+    env.globals['lab_results_repetitions'] = data['config']['lab_results_repetitions']
+else :
+  env.globals['lab_results_repetitions'] = 1
+env.globals['codeSystems'] = data["codeSystems"]
 
 xml_nsmap = {
         None: "urn:hl7-org:v3",
@@ -33,8 +50,10 @@ xml_nsmap = {
 # Render the template with your data
 rendered_xml = template.render(data, nsmap=xml_nsmap)
 
-# 5. Save the output to a new XML file
-with open("output.xml", "w", encoding="utf-8") as f:
+# Save the output to a new XML file - TODO: re-enabled timestamped filenames
+#output_filename = mapping_file.replace(".json", "-"+generate_timestamp(None, True)+".xml")
+output_filename = mapping_file.replace(".json", ".xml")
+with open(output_filename, "w", encoding="utf-8") as f:
     f.write(rendered_xml)
 
-print("XML file generated successfully!")
+print("XML file [" + output_filename + "] generated successfully!")

--- a/scripts/generate_ecr.py
+++ b/scripts/generate_ecr.py
@@ -69,9 +69,8 @@ xml_nsmap = {
 # Render the template with your data
 rendered_xml = template.render(data, nsmap=xml_nsmap)
 
-# Save the output to a new XML file - TODO: re-enabled timestamped filenames
-#output_filename = mapping_file.replace(".json", "-"+generate_timestamp(None, True)+".xml")
-output_filename = mapping_file.replace(".json", ".xml")
+# Save the output to a new XML file
+output_filename = mapping_file.replace(".json", "-"+generate_timestamp(None, True)+".xml")
 with open(output_filename, "w", encoding="utf-8") as f:
     f.write(rendered_xml)
 

--- a/scripts/generate_ecr.py
+++ b/scripts/generate_ecr.py
@@ -1,0 +1,40 @@
+from jinja2 import Environment, FileSystemLoader
+from pathlib import Path
+import json
+from utils import generate_uuid, generate_timestamp
+
+# Setup the Jinja environment to load templates
+env = Environment(
+    loader=FileSystemLoader(
+        Path(__file__).resolve().parent.parent / "assets" / "templates"
+    )
+)
+
+env.globals['uuid'] = generate_uuid
+env.globals['timestamp'] = generate_timestamp
+
+# Load the specific template file
+template = env.get_template('components/base.xml.j2')
+
+# Define the data you want to inject
+base_path = Path(__file__).resolve().parent.parent
+json_path = base_path / "assets" / "mappings" / "mon-mothma-covid.json"
+with open(json_path) as f:
+    data = json.load(f)
+
+xml_nsmap = {
+        None: "urn:hl7-org:v3",
+        "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "sdtc": "urn:hl7-org:sdtc",
+        "voc": "http://www.lantanagroup.com/voc",
+        "schema_location": "urn:hl7-org:v3 ../../schema/infrastructure/cda/CDA_SDTC.xsd"
+    }
+
+# Render the template with your data
+rendered_xml = template.render(data, nsmap=xml_nsmap)
+
+# 5. Save the output to a new XML file
+with open("output.xml", "w", encoding="utf-8") as f:
+    f.write(rendered_xml)
+
+print("XML file generated successfully!")

--- a/scripts/generate_ecr.py
+++ b/scripts/generate_ecr.py
@@ -32,12 +32,31 @@ with open(json_path) as f:
     data = json.load(f)
 
 # Set globals from data
+env.globals['codeSystems'] = data["codeSystems"]
+
+env.globals['lab_results_repetitions'] = 1
+env.globals['encounters_diagnosis_repetitions'] = 1
+env.globals['history_of_present_illness_repetitions'] = 1
+env.globals['problems_obs_repetitions'] = 1
+env.globals['medications_administered_repetitions'] = 1
+env.globals['immunization_activities_repetitions'] = 1
+env.globals['plan_of_treatment_repetitions'] = 1
+
 if 'config' in data :
   if 'lab_results_repetitions' in data['config']:
     env.globals['lab_results_repetitions'] = data['config']['lab_results_repetitions']
-else :
-  env.globals['lab_results_repetitions'] = 1
-env.globals['codeSystems'] = data["codeSystems"]
+  if 'encounters_diagnosis_repetitions' in data['config']:
+    env.globals['encounters_diagnosis_repetitions'] = data['config']['encounters_diagnosis_repetitions']
+  if 'history_of_present_illness_repetitions' in data['config']:
+    env.globals['history_of_present_illness_repetitions'] = data['config']['history_of_present_illness_repetitions']
+  if 'problems_obs_repetitions' in data['config']:
+    env.globals['problems_obs_repetitions'] = data['config']['problems_obs_repetitions']
+  if 'medications_administered_repetitions' in data['config']:
+    env.globals['medications_administered_repetitions'] = data['config']['medications_administered_repetitions']
+  if 'immunization_activities_repetitions' in data['config']:
+    env.globals['immunization_activities_repetitions'] = data['config']['immunization_activities_repetitions']
+  if 'plan_of_treatment_repetitions' in data['config']:
+    env.globals['plan_of_treatment_repetitions'] = data['config']['plan_of_treatment_repetitions']
 
 xml_nsmap = {
         None: "urn:hl7-org:v3",

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -5,13 +5,15 @@ def generate_uuid():
     return str(uuid.uuid4())
 
 
-def generate_timestamp(value=None):
+def generate_timestamp(value=None, simple=False):
     """
-    Generates a timestamp in YYYYMMDDHHMM-ZZZZ format.
+    Generates a timestamp in YYYYMMDDHHMM-ZZZZ or YYYYMMDDHHMM (simple) format .
     Defaults to current time if no value is provided.
     """
     # Use provided datetime object, or default to current UTC time
     dt = value if isinstance(value, datetime) else datetime.now(timezone.utc)
 
-    # %Y: Year, %m: Month, %d: Day, %H: Hour, %M: Minute, %z: timezone offset (+HHMM or -HHMM)
+    # %Y: Year, %m: Month, %d: Day, %H: Hour, %M: Minute, (optional) %z: timezone offset (+HHMM or -HHMM)
+    if simple:
+      return dt.strftime("%Y%m%d%H%M")
     return dt.strftime("%Y%m%d%H%M%z")

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,0 +1,17 @@
+import uuid
+from datetime import datetime, timezone
+
+def generate_uuid():
+    return str(uuid.uuid4())
+
+
+def generate_timestamp(value=None):
+    """
+    Generates a timestamp in YYYYMMDDHHMM-ZZZZ format.
+    Defaults to current time if no value is provided.
+    """
+    # Use provided datetime object, or default to current UTC time
+    dt = value if isinstance(value, datetime) else datetime.now(timezone.utc)
+
+    # %Y: Year, %m: Month, %d: Day, %H: Hour, %M: Minute, %z: timezone offset (+HHMM or -HHMM)
+    return dt.strftime("%Y%m%d%H%M%z")

--- a/tests/test-component-templates.py
+++ b/tests/test-component-templates.py
@@ -1,7 +1,7 @@
 from lxml import etree
 from conftest import normalize_xml
 
-
+# TODO: All of these tests are broken now
 def test_patient_template(jinja_env, patient_data, xml_nsmap, base_path):
     """Test that our template generates the expected patient XML structure."""
     # load and render the template


### PR DESCRIPTION
## Summary

These changes include a script to generate ECRs, updated template files, and an updated README. 

There is still a lot of work to do but this is a functional start that allows generating ECRs with synthetic data including very large ECRs by repeating blocks of data (driven by a config block in the json file). 

This is a big change so I don't expect a thorough review, its more for visibility. If we feel we should move this to main just approve the PR!

I am also happy to jump on a call to walk through this!
